### PR TITLE
style: rename abbreviated variables to descriptive PBP names

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -21,12 +21,12 @@ pub fn map_request_attributes(
     mapping_data: Option<&Value>,
 ) -> std::result::Result<HashMap<String, Value>, MappingError> {
     let data = mapping_data.unwrap_or(&MAPPING_DATA);
-    let Some(qd) = get_qualifier_data(qualifier, data) else {
+    let Some(qualifier_data) = get_qualifier_data(qualifier, data) else {
         return handle_unknown_qualifier(qualifier, attributes, "request", strict);
     };
-    let key_map = get_string_map(qd, "request_key_map");
-    let key_value_map = get_key_value_map(qd, "request_key_value_map");
-    let value_map = get_nested_string_map(qd, "request_value_map");
+    let key_map = get_string_map(qualifier_data, "request_key_map");
+    let key_value_map = get_key_value_map(qualifier_data, "request_key_value_map");
+    let value_map = get_nested_string_map(qualifier_data, "request_value_map");
     map_attributes(
         qualifier,
         attributes,
@@ -51,14 +51,20 @@ pub fn map_response_attributes(
     mapping_data: Option<&Value>,
 ) -> std::result::Result<HashMap<String, Value>, MappingError> {
     let data = mapping_data.unwrap_or(&MAPPING_DATA);
-    let Some(qd) = get_qualifier_data(qualifier, data) else {
+    let Some(qualifier_data) = get_qualifier_data(qualifier, data) else {
         return handle_unknown_qualifier(qualifier, attributes, "response", strict);
     };
-    let key_map = get_string_map(qd, "response_key_map");
-    let value_map = get_nested_string_map(qd, "response_value_map");
-    let empty_kvm = HashMap::new();
+    let key_map = get_string_map(qualifier_data, "response_key_map");
+    let value_map = get_nested_string_map(qualifier_data, "response_value_map");
+    let empty_key_value_map = HashMap::new();
     map_attributes(
-        qualifier, attributes, &key_map, &empty_kvm, &value_map, "response", strict,
+        qualifier,
+        attributes,
+        &key_map,
+        &empty_key_value_map,
+        &value_map,
+        "response",
+        strict,
     )
 }
 
@@ -75,12 +81,12 @@ pub fn map_response_list(
     mapping_data: Option<&Value>,
 ) -> std::result::Result<Vec<HashMap<String, Value>>, MappingError> {
     let data = mapping_data.unwrap_or(&MAPPING_DATA);
-    let Some(qd) = get_qualifier_data(qualifier, data) else {
+    let Some(qualifier_data) = get_qualifier_data(qualifier, data) else {
         return handle_unknown_qualifier_list(qualifier, objects, "response", strict);
     };
-    let key_map = get_string_map(qd, "response_key_map");
-    let value_map = get_nested_string_map(qd, "response_value_map");
-    let empty_kvm = HashMap::new();
+    let key_map = get_string_map(qualifier_data, "response_key_map");
+    let value_map = get_nested_string_map(qualifier_data, "response_value_map");
+    let empty_key_value_map = HashMap::new();
     let mut mapped_objects = Vec::with_capacity(objects.len());
     let mut issues = Vec::new();
     for (object_index, attributes) in objects.iter().enumerate() {
@@ -88,7 +94,7 @@ pub fn map_response_list(
             qualifier,
             attributes,
             &key_map,
-            &empty_kvm,
+            &empty_key_value_map,
             &value_map,
             "response",
             Some(object_index),
@@ -109,9 +115,9 @@ fn get_qualifier_data<'a>(qualifier: &str, data: &'a Value) -> Option<&'a Value>
 fn get_string_map(qualifier_data: &Value, map_name: &str) -> HashMap<String, String> {
     let mut result = HashMap::new();
     if let Some(obj) = qualifier_data.get(map_name).and_then(Value::as_object) {
-        for (k, v) in obj {
-            if let Some(s) = v.as_str() {
-                result.insert(k.clone(), s.to_owned());
+        for (key, value) in obj {
+            if let Some(s) = value.as_str() {
+                result.insert(key.clone(), s.to_owned());
             }
         }
     }
@@ -124,15 +130,15 @@ fn get_nested_string_map(
 ) -> HashMap<String, HashMap<String, String>> {
     let mut result = HashMap::new();
     if let Some(obj) = qualifier_data.get(map_name).and_then(Value::as_object) {
-        for (k, v) in obj {
-            if let Some(inner) = v.as_object() {
+        for (key, value) in obj {
+            if let Some(inner) = value.as_object() {
                 let mut inner_map = HashMap::new();
-                for (ik, iv) in inner {
-                    if let Some(s) = iv.as_str() {
-                        inner_map.insert(ik.clone(), s.to_owned());
+                for (inner_key, inner_value) in inner {
+                    if let Some(s) = inner_value.as_str() {
+                        inner_map.insert(inner_key.clone(), s.to_owned());
                     }
                 }
-                result.insert(k.clone(), inner_map);
+                result.insert(key.clone(), inner_map);
             }
         }
     }
@@ -144,21 +150,21 @@ type KeyValueMap = HashMap<String, HashMap<String, HashMap<String, String>>>;
 fn get_key_value_map(qualifier_data: &Value, map_name: &str) -> KeyValueMap {
     let mut result = HashMap::new();
     if let Some(obj) = qualifier_data.get(map_name).and_then(Value::as_object) {
-        for (k, v) in obj {
-            if let Some(inner) = v.as_object() {
+        for (key, value) in obj {
+            if let Some(inner) = value.as_object() {
                 let mut inner_map = HashMap::new();
-                for (ik, iv) in inner {
-                    if let Some(nested) = iv.as_object() {
+                for (inner_key, inner_value) in inner {
+                    if let Some(nested) = inner_value.as_object() {
                         let mut nested_map = HashMap::new();
-                        for (nk, nv) in nested {
-                            if let Some(s) = nv.as_str() {
-                                nested_map.insert(nk.clone(), s.to_owned());
+                        for (nested_key, nested_value) in nested {
+                            if let Some(s) = nested_value.as_str() {
+                                nested_map.insert(nested_key.clone(), s.to_owned());
                             }
                         }
-                        inner_map.insert(ik.clone(), nested_map);
+                        inner_map.insert(inner_key.clone(), nested_map);
                     }
                 }
-                result.insert(k.clone(), inner_map);
+                result.insert(key.clone(), inner_map);
             }
         }
     }

--- a/src/mapping_merge.rs
+++ b/src/mapping_merge.rs
@@ -117,8 +117,8 @@ fn merge_commands(merged: &mut Value, override_commands: Option<&Value>) {
     for (key, entry) in override_obj {
         if let Some(entry_obj) = entry.as_object() {
             if let Some(existing) = base_obj.get_mut(key).and_then(Value::as_object_mut) {
-                for (ek, ev) in entry_obj {
-                    existing.insert(ek.clone(), ev.clone());
+                for (entry_key, entry_value) in entry_obj {
+                    existing.insert(entry_key.clone(), entry_value.clone());
                 }
             } else {
                 base_obj.insert(key.clone(), entry.clone());
@@ -145,8 +145,8 @@ fn merge_qualifiers(merged: &mut Value, override_qualifiers: Option<&Value>) {
                         if let Some(existing_sub) =
                             existing.get_mut(sub_key).and_then(Value::as_object_mut)
                         {
-                            for (k, v) in sub_obj {
-                                existing_sub.insert(k.clone(), v.clone());
+                            for (key, value) in sub_obj {
+                                existing_sub.insert(key.clone(), value.clone());
                             }
                         } else {
                             existing.insert(sub_key.clone(), sub_value.clone());

--- a/src/session.rs
+++ b/src/session.rs
@@ -574,8 +574,8 @@ fn flatten_nested_objects(
             for nested in objects {
                 if let Some(obj) = nested.as_object() {
                     let mut merged = shared.clone();
-                    for (k, v) in obj {
-                        merged.insert(k.clone(), v.clone());
+                    for (key, value) in obj {
+                        merged.insert(key.clone(), value.clone());
                     }
                     flattened.push(merged);
                 }
@@ -631,7 +631,6 @@ fn extract_command_response(
 }
 
 fn raise_for_command_errors(payload: &HashMap<String, Value>, status_code: u16) -> Result<()> {
-    #[allow(clippy::similar_names)]
     let completion_code = extract_optional_i64(payload.get("overallCompletionCode"));
     let reason_code = extract_optional_i64(payload.get("overallReasonCode"));
     let has_overall_error = has_error_codes(completion_code, reason_code);
@@ -640,13 +639,13 @@ fn raise_for_command_errors(payload: &HashMap<String, Value>, status_code: u16) 
     if let Some(Value::Array(cr)) = payload.get("commandResponse") {
         for (idx, item) in cr.iter().enumerate() {
             if let Some(obj) = item.as_object() {
-                let cc = extract_optional_i64(obj.get("completionCode"));
-                let rc = extract_optional_i64(obj.get("reasonCode"));
-                if has_error_codes(cc, rc) {
+                let completion_code = extract_optional_i64(obj.get("completionCode"));
+                let reason_code = extract_optional_i64(obj.get("reasonCode"));
+                if has_error_codes(completion_code, reason_code) {
                     command_issues.push(format!(
                         "index={idx} completionCode={} reasonCode={}",
-                        cc.unwrap_or(0),
-                        rc.unwrap_or(0),
+                        completion_code.unwrap_or(0),
+                        reason_code.unwrap_or(0),
                     ));
                 }
             }
@@ -679,8 +678,8 @@ fn extract_optional_i64(value: Option<&Value>) -> Option<i64> {
     value.and_then(Value::as_i64)
 }
 
-const fn has_error_codes(cc: Option<i64>, rc: Option<i64>) -> bool {
-    matches!(cc, Some(c) if c != 0) || matches!(rc, Some(r) if r != 0)
+const fn has_error_codes(completion_code: Option<i64>, reason_code: Option<i64>) -> bool {
+    matches!(completion_code, Some(c) if c != 0) || matches!(reason_code, Some(r) if r != 0)
 }
 
 fn get_command_map(mapping_data: &Value) -> HashMap<String, Value> {
@@ -729,11 +728,11 @@ fn build_unknown_qualifier_issue(qualifier: &str) -> Vec<MappingIssue> {
 
 fn build_snake_to_mqsc_map(qualifier_entry: &Value) -> HashMap<String, String> {
     let mut response_lookup: HashMap<String, String> = HashMap::new();
-    if let Some(rkm) = qualifier_entry
+    if let Some(response_key_map) = qualifier_entry
         .get("response_key_map")
         .and_then(Value::as_object)
     {
-        for (mqsc_key, snake_val) in rkm {
+        for (mqsc_key, snake_val) in response_key_map {
             if let Some(snake_key) = snake_val.as_str() {
                 response_lookup
                     .entry(snake_key.to_owned())
@@ -742,11 +741,11 @@ fn build_snake_to_mqsc_map(qualifier_entry: &Value) -> HashMap<String, String> {
         }
     }
     let mut combined = response_lookup;
-    if let Some(rkm) = qualifier_entry
+    if let Some(request_key_map) = qualifier_entry
         .get("request_key_map")
         .and_then(Value::as_object)
     {
-        for (snake_key, mqsc_val) in rkm {
+        for (snake_key, mqsc_val) in request_key_map {
             if let Some(mqsc_key) = mqsc_val.as_str() {
                 combined.insert(snake_key.clone(), mqsc_key.to_owned());
             }
@@ -776,8 +775,8 @@ fn map_where_keyword(
     };
 
     let combined_map = build_snake_to_mqsc_map(entry);
-    let mapped_keyword = if let Some(mk) = combined_map.get(keyword) {
-        mk.clone()
+    let mapped_keyword = if let Some(mqsc_key) = combined_map.get(keyword) {
+        mqsc_key.clone()
     } else {
         if strict {
             return Err(MappingError::new(vec![MappingIssue {


### PR DESCRIPTION
# Pull Request

## Summary

- Rename 16 abbreviated variables to descriptive PBP names across mapping.rs, session.rs, and mapping_merge.rs

## Issue Linkage

- Fixes #11

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -