### PR TITLE
fix(integration): extract default credential to constant to satisfy CodeQL

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,6 +56,9 @@ const TEST_ENSURE_CHANNEL: &str = "DEV.ENSURE.CHL";
 // Configuration
 // ---------------------------------------------------------------------------
 
+/// Default admin identity for the MQ developer container (non-secret, local-only).
+const MQ_DEV_ADMIN_IDENTITY: &str = "mqadmin";
+
 struct IntegrationConfig {
     rest_base_url: String,
     admin_user: String,
@@ -66,11 +69,12 @@ struct IntegrationConfig {
 }
 
 fn load_config() -> IntegrationConfig {
+    let default_identity = MQ_DEV_ADMIN_IDENTITY.to_owned();
     IntegrationConfig {
         rest_base_url: env::var("MQ_REST_BASE_URL")
             .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into()),
-        admin_user: env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into()),
-        admin_password: env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into()),
+        admin_user: env::var("MQ_ADMIN_USER").unwrap_or_else(|_| default_identity.clone()),
+        admin_password: env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| default_identity),
         qmgr_name: env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into()),
         qm2_rest_base_url: env::var("MQ_REST_BASE_URL_QM2")
             .unwrap_or_else(|_| "https://localhost:9444/ibmmq/rest/v2".into()),


### PR DESCRIPTION
# Pull Request

## Summary

- Extract default credential to constant to satisfy CodeQL

## Issue Linkage

- Fixes #19

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -