### PR TITLE
feat(examples): refactor examples to dual-mode with importable functions, tests, and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: cargo clippy
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --fail-under-lines 100
+        run: cargo llvm-cov --features examples --fail-under-lines 100
 
   # ---------------------------------------------------------------------------
   # Integration tests — matrix over Rust versions with unique MQ ports
@@ -161,4 +161,4 @@ jobs:
         env:
           MQ_REST_BASE_URL: https://localhost:${{ matrix.qm1-rest-port }}/ibmmq/rest/v2
           MQ_REST_BASE_URL_QM2: https://localhost:${{ matrix.qm2-rest-port }}/ibmmq/rest/v2
-        run: cargo test --features integration
+        run: cargo test --features integration,examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ paste = "1"
 
 [features]
 integration = []
+examples = []
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/channel_status.rs
+++ b/examples/channel_status.rs
@@ -4,30 +4,12 @@
 //! channels that are defined but not running, and shows connection details.
 //!
 //! ```text
-//! cargo run --example channel_status
+//! cargo run --features examples --example channel_status
 //! ```
 
-use std::collections::HashMap;
 use std::env;
 
-use mq_rest_admin::{Credentials, MqRestSession};
-use serde_json::Value;
-
-struct ChannelInfo {
-    name: String,
-    channel_type: String,
-    connection_name: String,
-    defined: bool,
-    status: String,
-}
-
-fn get_str(map: &HashMap<String, Value>, key: &str) -> String {
-    map.get(key)
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
+use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
@@ -44,67 +26,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .verify_tls(false)
     .build()?;
 
-    // Collect channel definitions
-    let channels = session.display_channel(Some("*"), None, None, None)?;
-    let mut definitions: HashMap<String, HashMap<String, Value>> = HashMap::new();
-    for channel in channels {
-        let cname = get_str(&channel, "channel_name");
-        if !cname.is_empty() {
-            definitions.insert(cname, channel);
-        }
-    }
+    let results = examples::report_channel_status(&mut session)?;
 
-    // Collect live status
-    let mut live_status: HashMap<String, String> = HashMap::new();
-    if let Ok(statuses) = session.display_chstatus(Some("*"), None, None, None) {
-        for entry in statuses {
-            let cname = get_str(&entry, "channel_name");
-            let cstatus = get_str(&entry, "status");
-            if !cname.is_empty() {
-                live_status.insert(cname, cstatus);
-            }
-        }
-    }
-
-    // Merge definitions and status
-    let mut results: Vec<ChannelInfo> = Vec::new();
-
-    let mut def_names: Vec<&String> = definitions.keys().collect();
-    def_names.sort();
-    for cname in def_names {
-        let defn = &definitions[cname];
-        let ctype = get_str(defn, "channel_type");
-        let conname = get_str(defn, "connection_name");
-        let status = live_status
-            .get(cname)
-            .cloned()
-            .unwrap_or_else(|| "INACTIVE".into());
-
-        results.push(ChannelInfo {
-            name: cname.clone(),
-            channel_type: ctype,
-            connection_name: conname,
-            defined: true,
-            status,
-        });
-    }
-
-    // Channels with status but no definition
-    let mut status_names: Vec<&String> = live_status.keys().collect();
-    status_names.sort();
-    for cname in status_names {
-        if !definitions.contains_key(cname) {
-            results.push(ChannelInfo {
-                name: cname.clone(),
-                channel_type: String::new(),
-                connection_name: String::new(),
-                defined: false,
-                status: live_status[cname].clone(),
-            });
-        }
-    }
-
-    // Print report
     println!(
         "\n{:<30} {:<12} {:<25} {:<8} Status",
         "Channel", "Type", "Connection", "Defined"
@@ -119,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let inactive: Vec<&ChannelInfo> = results
+    let inactive: Vec<_> = results
         .iter()
         .filter(|c| c.defined && c.status == "INACTIVE")
         .collect();

--- a/examples/dlq_inspector.rs
+++ b/examples/dlq_inspector.rs
@@ -5,32 +5,12 @@
 //! are present.
 //!
 //! ```text
-//! cargo run --example dlq_inspector
+//! cargo run --features examples --example dlq_inspector
 //! ```
 
-use std::collections::HashMap;
 use std::env;
 
-use mq_rest_admin::{Credentials, MqRestSession};
-use serde_json::Value;
-
-const CRITICAL_DEPTH_PCT: f64 = 90.0;
-
-fn get_str(map: &HashMap<String, Value>, key: &str) -> String {
-    map.get(key)
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
-
-fn get_i64(map: &HashMap<String, Value>, key: &str) -> i64 {
-    match map.get(key) {
-        Some(Value::Number(n)) => n.as_i64().unwrap_or(0),
-        Some(Value::String(s)) => s.trim().parse().unwrap_or(0),
-        _ => 0,
-    }
-}
+use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
@@ -47,60 +27,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .verify_tls(false)
     .build()?;
 
-    let qmgr = session.display_qmgr(None, None)?;
-
-    let dlq_name = qmgr
-        .as_ref()
-        .map(|q| get_str(q, "dead_letter_queue_name"))
-        .unwrap_or_default();
+    let report = examples::inspect_dlq(&mut session)?;
 
     println!("\n=== Dead Letter Queue: {} ===", session.qmgr_name());
+    println!("  Configured: {}", report.configured);
 
-    if dlq_name.is_empty() {
-        println!("  Configured: false");
+    if report.dlq_name.is_empty() {
         println!("  DLQ name:   (none)");
+    } else {
+        println!("  DLQ name:   {}", report.dlq_name);
         println!(
-            "  Suggestion: No dead letter queue configured. Define one with ALTER QMGR DEADQ."
+            "  Depth:      {} / {} ({:.1}%)",
+            report.current_depth, report.max_depth, report.depth_pct
         );
-        return Ok(());
+        println!("  Input:      {}", report.open_input);
+        println!("  Output:     {}", report.open_output);
     }
 
-    println!("  Configured: true");
-    println!("  DLQ name:   {dlq_name}");
-
-    let queues = session.display_queue(Some(&dlq_name), None, None, None)?;
-    if queues.is_empty() {
-        println!("  Suggestion: DLQ '{dlq_name}' is configured but the queue does not exist.");
-        return Ok(());
-    }
-
-    let dlq = &queues[0];
-    let current_depth = get_i64(dlq, "current_queue_depth");
-    let max_depth = get_i64(dlq, "max_queue_depth");
-    let open_input = get_i64(dlq, "open_input_count");
-    let open_output = get_i64(dlq, "open_output_count");
-
-    #[allow(clippy::cast_precision_loss)]
-    let depth_pct = if max_depth > 0 {
-        current_depth as f64 / max_depth as f64 * 100.0
-    } else {
-        0.0
-    };
-
-    println!("  Depth:      {current_depth} / {max_depth} ({depth_pct:.1}%)");
-    println!("  Input:      {open_input}");
-    println!("  Output:     {open_output}");
-
-    let suggestion = if current_depth == 0 {
-        "DLQ is empty. No action needed."
-    } else if depth_pct >= CRITICAL_DEPTH_PCT {
-        "DLQ is near capacity. Investigate and clear undeliverable messages urgently."
-    } else if current_depth > 0 {
-        "DLQ has messages. Investigate undeliverable messages."
-    } else {
-        "DLQ is healthy."
-    };
-    println!("  Suggestion: {suggestion}");
+    println!("  Suggestion: {}", report.suggestion);
 
     Ok(())
 }

--- a/examples/health_check.rs
+++ b/examples/health_check.rs
@@ -5,53 +5,14 @@
 //! pass/fail summary for each queue manager.
 //!
 //! ```text
-//! cargo run --example health_check
+//! cargo run --features examples --example health_check
 //! ```
 //!
 //! Set `MQ_REST_BASE_URL_QM2` to also check QM2.
 
-use std::collections::HashMap;
 use std::env;
 
-use mq_rest_admin::{Credentials, MqRestSession};
-use serde_json::Value;
-
-fn get_str(map: &HashMap<String, Value>, key: &str) -> String {
-    map.get(key)
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
-
-fn check_health(session: &mut MqRestSession) -> (bool, String, String, Vec<(String, String)>) {
-    let mut status = "UNKNOWN".to_string();
-    let mut command_server = "UNKNOWN".to_string();
-    let mut listeners: Vec<(String, String)> = Vec::new();
-
-    let Ok(_qmgr) = session.display_qmgr(None, None) else {
-        return (false, status, command_server, listeners);
-    };
-
-    if let Ok(Some(qs)) = session.display_qmstatus(None, None) {
-        status = get_str(&qs, "ha_status");
-    }
-
-    if let Ok(Some(cs)) = session.display_cmdserv(None, None) {
-        command_server = get_str(&cs, "status");
-    }
-
-    if let Ok(lst) = session.display_listener(Some("*"), None, None, None) {
-        for listener in lst {
-            let lname = get_str(&listener, "listener_name");
-            let lstatus = get_str(&listener, "start_mode");
-            listeners.push((lname, lstatus));
-        }
-    }
-
-    let passed = status != "UNKNOWN";
-    (passed, status, command_server, listeners)
-}
+use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
@@ -86,16 +47,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     for (label, session) in &mut sessions {
-        let (passed, status, command_server, listeners) = check_health(session);
-        let verdict = if passed { "PASS" } else { "FAIL" };
+        let result = examples::check_health(session)?;
+        let verdict = if result.passed { "PASS" } else { "FAIL" };
 
         println!("\n=== {label}: {verdict} ===");
-        println!("  Reachable:      {}", passed || status != "UNKNOWN");
-        println!("  Status:         {status}");
-        println!("  Command server: {command_server}");
-        println!("  Listeners:      {}", listeners.len());
-        for (lname, lstatus) in &listeners {
-            println!("    {lname}: {lstatus}");
+        println!("  Reachable:      {}", result.reachable);
+        println!("  Status:         {}", result.status);
+        println!("  Command server: {}", result.command_server);
+        println!("  Listeners:      {}", result.listeners.len());
+        for listener in &result.listeners {
+            println!("    {}: {}", listener.name, listener.start_mode);
         }
     }
 

--- a/examples/provision_environment.rs
+++ b/examples/provision_environment.rs
@@ -5,276 +5,15 @@
 //! Includes teardown to remove all provisioned objects.
 //!
 //! ```text
-//! cargo run --example provision_environment
+//! cargo run --features examples --example provision_environment
 //! ```
 //!
 //! Requires both QM1 and QM2 to be running. Set `MQ_REST_BASE_URL_QM2`
 //! to the QM2 REST endpoint (default: `https://localhost:9444/ibmmq/rest/v2`).
 
-use std::collections::HashMap;
 use std::env;
 
-use mq_rest_admin::{Credentials, MqRestSession};
-use serde_json::Value;
-
-const PREFIX: &str = "PROV";
-
-fn define(
-    session: &mut MqRestSession,
-    method: &str,
-    name: &str,
-    params: &HashMap<String, Value>,
-    created: &mut Vec<String>,
-    failed: &mut Vec<String>,
-) {
-    let label = format!("{}/{name}", session.qmgr_name());
-    let result = match method {
-        "define_qlocal" => session.define_qlocal(name, Some(params), None),
-        "define_qremote" => session.define_qremote(name, Some(params), None),
-        "define_channel" => session.define_channel(name, Some(params), None),
-        _ => unreachable!(),
-    };
-    match result {
-        Ok(()) => created.push(label),
-        Err(_) => failed.push(label),
-    }
-}
-
-fn delete(
-    session: &mut MqRestSession,
-    method: &str,
-    name: &str,
-    label: &str,
-    failures: &mut Vec<String>,
-) {
-    let result = match method {
-        "delete_queue" => session.delete_queue(name, None, None),
-        "delete_channel" => session.delete_channel(name, None, None),
-        _ => unreachable!(),
-    };
-    if result.is_err() {
-        failures.push(format!("{label}/{name}"));
-    }
-}
-
-fn params(entries: &[(&str, &str)]) -> HashMap<String, Value> {
-    entries
-        .iter()
-        .map(|(k, v)| ((*k).to_string(), Value::String((*v).to_string())))
-        .collect()
-}
-
-fn define_queues(
-    qm1: &mut MqRestSession,
-    qm2: &mut MqRestSession,
-    created: &mut Vec<String>,
-    failed: &mut Vec<String>,
-) {
-    // Local queues
-    define(
-        qm1,
-        "define_qlocal",
-        &format!("{PREFIX}.QM1.LOCAL"),
-        &params(&[
-            ("replace", "yes"),
-            ("default_persistence", "yes"),
-            ("description", "provisioned local queue on QM1"),
-        ]),
-        created,
-        failed,
-    );
-    define(
-        qm2,
-        "define_qlocal",
-        &format!("{PREFIX}.QM2.LOCAL"),
-        &params(&[
-            ("replace", "yes"),
-            ("default_persistence", "yes"),
-            ("description", "provisioned local queue on QM2"),
-        ]),
-        created,
-        failed,
-    );
-
-    // Transmission queues
-    define(
-        qm1,
-        "define_qlocal",
-        &format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
-        &params(&[
-            ("replace", "yes"),
-            ("usage", "XMITQ"),
-            ("description", "xmit queue QM1 to QM2"),
-        ]),
-        created,
-        failed,
-    );
-    define(
-        qm2,
-        "define_qlocal",
-        &format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
-        &params(&[
-            ("replace", "yes"),
-            ("usage", "XMITQ"),
-            ("description", "xmit queue QM2 to QM1"),
-        ]),
-        created,
-        failed,
-    );
-
-    // Remote queues
-    define(
-        qm1,
-        "define_qremote",
-        &format!("{PREFIX}.REMOTE.TO.QM2"),
-        &params(&[
-            ("replace", "yes"),
-            ("remote_queue_name", &format!("{PREFIX}.QM2.LOCAL")),
-            ("remote_queue_manager_name", "QM2"),
-            (
-                "transmission_queue_name",
-                &format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
-            ),
-            ("description", "remote queue QM1 to QM2"),
-        ]),
-        created,
-        failed,
-    );
-    define(
-        qm2,
-        "define_qremote",
-        &format!("{PREFIX}.REMOTE.TO.QM1"),
-        &params(&[
-            ("replace", "yes"),
-            ("remote_queue_name", &format!("{PREFIX}.QM1.LOCAL")),
-            ("remote_queue_manager_name", "QM1"),
-            (
-                "transmission_queue_name",
-                &format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
-            ),
-            ("description", "remote queue QM2 to QM1"),
-        ]),
-        created,
-        failed,
-    );
-}
-
-fn define_channels(
-    qm1: &mut MqRestSession,
-    qm2: &mut MqRestSession,
-    created: &mut Vec<String>,
-    failed: &mut Vec<String>,
-) {
-    define(
-        qm1,
-        "define_channel",
-        &format!("{PREFIX}.QM1.TO.QM2"),
-        &params(&[
-            ("replace", "yes"),
-            ("channel_type", "SDR"),
-            ("transport_type", "TCP"),
-            ("connection_name", "qm2(1414)"),
-            (
-                "transmission_queue_name",
-                &format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
-            ),
-            ("description", "sender QM1 to QM2"),
-        ]),
-        created,
-        failed,
-    );
-    define(
-        qm2,
-        "define_channel",
-        &format!("{PREFIX}.QM1.TO.QM2"),
-        &params(&[
-            ("replace", "yes"),
-            ("channel_type", "RCVR"),
-            ("transport_type", "TCP"),
-            ("description", "receiver QM1 to QM2"),
-        ]),
-        created,
-        failed,
-    );
-    define(
-        qm2,
-        "define_channel",
-        &format!("{PREFIX}.QM2.TO.QM1"),
-        &params(&[
-            ("replace", "yes"),
-            ("channel_type", "SDR"),
-            ("transport_type", "TCP"),
-            ("connection_name", "qm1(1414)"),
-            (
-                "transmission_queue_name",
-                &format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
-            ),
-            ("description", "sender QM2 to QM1"),
-        ]),
-        created,
-        failed,
-    );
-    define(
-        qm1,
-        "define_channel",
-        &format!("{PREFIX}.QM2.TO.QM1"),
-        &params(&[
-            ("replace", "yes"),
-            ("channel_type", "RCVR"),
-            ("transport_type", "TCP"),
-            ("description", "receiver QM2 to QM1"),
-        ]),
-        created,
-        failed,
-    );
-}
-
-fn provision(qm1: &mut MqRestSession, qm2: &mut MqRestSession) -> (Vec<String>, Vec<String>, bool) {
-    let mut created: Vec<String> = Vec::new();
-    let mut failed: Vec<String> = Vec::new();
-
-    define_queues(qm1, qm2, &mut created, &mut failed);
-    define_channels(qm1, qm2, &mut created, &mut failed);
-
-    // Verify
-    let verified = match (
-        qm1.display_queue(Some(&format!("{PREFIX}.*")), None, None, None),
-        qm2.display_queue(Some(&format!("{PREFIX}.*")), None, None, None),
-    ) {
-        (Ok(q1), Ok(q2)) => q1.len() >= 3 && q2.len() >= 3,
-        _ => false,
-    };
-
-    (created, failed, verified)
-}
-
-fn teardown(qm1: &mut MqRestSession, qm2: &mut MqRestSession) -> Vec<String> {
-    let mut failures: Vec<String> = Vec::new();
-
-    let channels = [
-        format!("{PREFIX}.QM1.TO.QM2"),
-        format!("{PREFIX}.QM2.TO.QM1"),
-    ];
-    let queues = [
-        format!("{PREFIX}.REMOTE.TO.QM1"),
-        format!("{PREFIX}.REMOTE.TO.QM2"),
-        format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
-        format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
-        format!("{PREFIX}.QM1.LOCAL"),
-        format!("{PREFIX}.QM2.LOCAL"),
-    ];
-
-    for (session, label) in [(&mut *qm1, "QM1"), (&mut *qm2, "QM2")] {
-        for channel in &channels {
-            delete(session, "delete_channel", channel, label, &mut failures);
-        }
-        for queue in &queues {
-            delete(session, "delete_queue", queue, label, &mut failures);
-        }
-    }
-
-    failures
-}
+use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let username = env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into());
@@ -301,22 +40,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     println!("\n=== Provisioning environment ===");
-    let (created, failed, verified) = provision(&mut qm1, &mut qm2);
+    let result = examples::provision(&mut qm1, &mut qm2)?;
 
-    println!("\nCreated: {}", created.len());
-    for obj in &created {
+    println!("\nCreated: {}", result.objects_created.len());
+    for obj in &result.objects_created {
         println!("  + {obj}");
     }
-    if !failed.is_empty() {
-        println!("\nFailed: {}", failed.len());
-        for obj in &failed {
+    if !result.failures.is_empty() {
+        println!("\nFailed: {}", result.failures.len());
+        for obj in &result.failures {
             println!("  ! {obj}");
         }
     }
-    println!("\nVerified: {verified}");
+    println!("\nVerified: {}", result.verified);
 
     println!("\n=== Tearing down ===");
-    let teardown_failures = teardown(&mut qm1, &mut qm2);
+    let teardown_failures = examples::teardown(&mut qm1, &mut qm2)?;
     if teardown_failures.is_empty() {
         println!("Teardown complete.");
     } else {

--- a/examples/queue_depth_monitor.rs
+++ b/examples/queue_depth_monitor.rs
@@ -4,42 +4,14 @@
 //! are approaching capacity, and sorts by depth percentage descending.
 //!
 //! ```text
-//! cargo run --example queue_depth_monitor
+//! cargo run --features examples --example queue_depth_monitor
 //! ```
 //!
 //! Set `DEPTH_THRESHOLD_PCT` to change the warning threshold (default 80).
 
-use std::collections::HashMap;
 use std::env;
 
-use mq_rest_admin::{Credentials, MqRestSession};
-use serde_json::Value;
-
-fn get_str(map: &HashMap<String, Value>, key: &str) -> String {
-    map.get(key)
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
-
-fn get_i64(map: &HashMap<String, Value>, key: &str) -> i64 {
-    match map.get(key) {
-        Some(Value::Number(n)) => n.as_i64().unwrap_or(0),
-        Some(Value::String(s)) => s.trim().parse().unwrap_or(0),
-        _ => 0,
-    }
-}
-
-struct QueueDepthInfo {
-    name: String,
-    current_depth: i64,
-    max_depth: i64,
-    depth_pct: f64,
-    open_input: i64,
-    open_output: i64,
-    warning: bool,
-}
+use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
@@ -60,37 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .verify_tls(false)
     .build()?;
 
-    let queues = session.display_queue(Some("*"), None, None, None)?;
-    let mut results: Vec<QueueDepthInfo> = Vec::new();
-
-    for queue in &queues {
-        let qtype = get_str(queue, "type").to_uppercase();
-        if qtype != "QLOCAL" && qtype != "LOCAL" {
-            continue;
-        }
-
-        let current_depth = get_i64(queue, "current_queue_depth");
-        let max_depth = get_i64(queue, "max_queue_depth");
-
-        #[allow(clippy::cast_precision_loss)]
-        let depth_pct = if max_depth > 0 {
-            current_depth as f64 / max_depth as f64 * 100.0
-        } else {
-            0.0
-        };
-
-        results.push(QueueDepthInfo {
-            name: get_str(queue, "queue_name"),
-            current_depth,
-            max_depth,
-            depth_pct,
-            open_input: get_i64(queue, "open_input_count"),
-            open_output: get_i64(queue, "open_output_count"),
-            warning: depth_pct >= threshold_pct,
-        });
-    }
-
-    results.sort_by(|a, b| b.depth_pct.total_cmp(&a.depth_pct));
+    let results = examples::monitor_queue_depths(&mut session, threshold_pct)?;
 
     println!(
         "\n{:<40} {:>8} {:>8} {:>6} {:>4} {:>4} Status",

--- a/examples/queue_status.rs
+++ b/examples/queue_status.rs
@@ -6,22 +6,12 @@
 //! `HashMap`s.
 //!
 //! ```text
-//! cargo run --example queue_status
+//! cargo run --features examples --example queue_status
 //! ```
 
-use std::collections::HashMap;
 use std::env;
 
-use mq_rest_admin::{Credentials, MqRestSession};
-use serde_json::Value;
-
-fn get_str(map: &HashMap<String, Value>, key: &str) -> String {
-    map.get(key)
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
+use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
@@ -39,12 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .build()?;
 
     // Queue status with TYPE(HANDLE)
-    let mut qstatus_params: HashMap<String, Value> = HashMap::new();
-    qstatus_params.insert("type".into(), Value::String("HANDLE".into()));
-
-    let queue_handles = session
-        .display_qstatus(Some("*"), Some(&qstatus_params), None, None)
-        .unwrap_or_default();
+    let queue_handles = examples::report_queue_handles(&mut session)?;
 
     println!(
         "\n{:<30} {:<15} {:<30} Open Options",
@@ -58,24 +43,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         for entry in &queue_handles {
             println!(
                 "{:<30} {:<15} {:<30} {}",
-                get_str(entry, "queue_name"),
-                get_str(entry, "handle_state"),
-                get_str(entry, "connection_id"),
-                get_str(entry, "open_options"),
+                entry.queue_name, entry.handle_state, entry.connection_id, entry.open_options,
             );
         }
     }
 
     // Connection handles with TYPE(HANDLE)
-    let mut conn_params: HashMap<String, Value> = HashMap::new();
-    conn_params.insert(
-        "connection_info_type".into(),
-        Value::String("HANDLE".into()),
-    );
-
-    let conn_handles = session
-        .display_conn(Some("*"), Some(&conn_params), None, None)
-        .unwrap_or_default();
+    let conn_handles = examples::report_connection_handles(&mut session)?;
 
     println!(
         "\n{:<30} {:<30} {:<15} Object Type",
@@ -89,10 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         for entry in &conn_handles {
             println!(
                 "{:<30} {:<30} {:<15} {}",
-                get_str(entry, "connection_id"),
-                get_str(entry, "object_name"),
-                get_str(entry, "handle_state"),
-                get_str(entry, "object_type"),
+                entry.connection_id, entry.object_name, entry.handle_state, entry.object_type,
             );
         }
     }

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-rust:1.93}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-cargo llvm-cov --fail-under-lines 100}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-cargo llvm-cov --features examples --fail-under-lines 100}"
 
 if command -v docker-test >/dev/null 2>&1; then
   exec docker-test

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -1,0 +1,1361 @@
+//! Importable example functions for the MQ REST admin library.
+//!
+//! This module provides the logic behind the `examples/*.rs` binaries as
+//! public, testable functions.  Each function accepts an `&mut MqRestSession`
+//! and returns a typed result struct.
+//!
+//! Enable with the `examples` Cargo feature:
+//!
+//! ```text
+//! cargo test --features examples
+//! cargo run  --features examples --example health_check
+//! ```
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::session::MqRestSession;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn get_str(map: &HashMap<String, Value>, key: &str) -> String {
+    map.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn get_i64(map: &HashMap<String, Value>, key: &str) -> i64 {
+    match map.get(key) {
+        Some(Value::Number(n)) => n.as_i64().unwrap_or(0),
+        Some(Value::String(s)) => s.trim().parse().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result structs
+// ---------------------------------------------------------------------------
+
+/// Health check result for a single queue manager.
+pub struct HealthCheckResult {
+    /// Whether the queue manager REST endpoint is reachable.
+    pub reachable: bool,
+    /// Whether all health checks passed.
+    pub passed: bool,
+    /// Queue manager name as reported by the endpoint.
+    pub qmgr_name: String,
+    /// HA status string (e.g. `"RUNNING"`).
+    pub status: String,
+    /// Command server status (e.g. `"RUNNING"`).
+    pub command_server: String,
+    /// Listener definitions with their start modes.
+    pub listeners: Vec<ListenerInfo>,
+}
+
+/// A single listener returned by the health check.
+pub struct ListenerInfo {
+    /// Listener name.
+    pub name: String,
+    /// Start mode (e.g. `"QMGR"`, `"MANUAL"`).
+    pub start_mode: String,
+}
+
+/// Depth information for a single local queue.
+pub struct QueueDepthInfo {
+    /// Queue name.
+    pub name: String,
+    /// Current message depth.
+    pub current_depth: i64,
+    /// Maximum queue depth.
+    pub max_depth: i64,
+    /// Depth as a percentage of maximum.
+    pub depth_pct: f64,
+    /// Number of open-for-input handles.
+    pub open_input: i64,
+    /// Number of open-for-output handles.
+    pub open_output: i64,
+    /// Whether the depth exceeds the threshold.
+    pub warning: bool,
+}
+
+/// Channel definition merged with live status.
+pub struct ChannelInfo {
+    /// Channel name.
+    pub name: String,
+    /// Channel type (e.g. `"SDR"`, `"RCVR"`, `"SVRCONN"`).
+    pub channel_type: String,
+    /// Connection name from the definition.
+    pub connection_name: String,
+    /// Whether a definition exists for this channel.
+    pub defined: bool,
+    /// Live status or `"INACTIVE"` if not running.
+    pub status: String,
+}
+
+/// Dead letter queue inspection report.
+pub struct DlqReport {
+    /// Whether a DLQ is configured on the queue manager.
+    pub configured: bool,
+    /// DLQ name (empty if not configured).
+    pub dlq_name: String,
+    /// Current message depth.
+    pub current_depth: i64,
+    /// Maximum queue depth.
+    pub max_depth: i64,
+    /// Depth as a percentage of maximum.
+    pub depth_pct: f64,
+    /// Number of open-for-input handles.
+    pub open_input: i64,
+    /// Number of open-for-output handles.
+    pub open_output: i64,
+    /// Actionable suggestion based on depth.
+    pub suggestion: String,
+}
+
+/// A single queue handle entry from `DISPLAY QSTATUS TYPE(HANDLE)`.
+pub struct QueueHandleInfo {
+    /// Queue name.
+    pub queue_name: String,
+    /// Handle state.
+    pub handle_state: String,
+    /// Connection identifier.
+    pub connection_id: String,
+    /// Open options.
+    pub open_options: String,
+}
+
+/// A single connection handle entry from `DISPLAY CONN TYPE(HANDLE)`.
+pub struct ConnectionHandleInfo {
+    /// Connection identifier.
+    pub connection_id: String,
+    /// Object name.
+    pub object_name: String,
+    /// Handle state.
+    pub handle_state: String,
+    /// Object type.
+    pub object_type: String,
+}
+
+/// Result of provisioning objects across two queue managers.
+pub struct ProvisionResult {
+    /// Successfully created objects (`"QM/NAME"` format).
+    pub objects_created: Vec<String>,
+    /// Objects that failed to create.
+    pub failures: Vec<String>,
+    /// Whether post-provision verification passed.
+    pub verified: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Public functions
+// ---------------------------------------------------------------------------
+
+/// Perform a health check on a queue manager.
+///
+/// Checks QMGR status, command server availability, and listener state.
+pub fn check_health(session: &mut MqRestSession) -> Result<HealthCheckResult> {
+    let mut status = "UNKNOWN".to_string();
+    let mut command_server = "UNKNOWN".to_string();
+    let mut listeners: Vec<ListenerInfo> = Vec::new();
+    let qmgr_name = session.qmgr_name().to_string();
+
+    let Ok(_qmgr) = session.display_qmgr(None, None) else {
+        return Ok(HealthCheckResult {
+            reachable: false,
+            passed: false,
+            qmgr_name,
+            status,
+            command_server,
+            listeners,
+        });
+    };
+
+    if let Ok(Some(qs)) = session.display_qmstatus(None, None) {
+        status = get_str(&qs, "ha_status");
+    }
+
+    if let Ok(Some(cs)) = session.display_cmdserv(None, None) {
+        command_server = get_str(&cs, "status");
+    }
+
+    if let Ok(lst) = session.display_listener(Some("*"), None, None, None) {
+        for listener in lst {
+            listeners.push(ListenerInfo {
+                name: get_str(&listener, "listener_name"),
+                start_mode: get_str(&listener, "start_mode"),
+            });
+        }
+    }
+
+    let passed = status != "UNKNOWN";
+    Ok(HealthCheckResult {
+        reachable: true,
+        passed,
+        qmgr_name,
+        status,
+        command_server,
+        listeners,
+    })
+}
+
+/// Monitor local queue depths and flag queues above the given threshold.
+///
+/// Returns queue depth information sorted by depth percentage descending.
+pub fn monitor_queue_depths(
+    session: &mut MqRestSession,
+    threshold_pct: f64,
+) -> Result<Vec<QueueDepthInfo>> {
+    let queues = session.display_queue(Some("*"), None, None, None)?;
+    let mut results: Vec<QueueDepthInfo> = Vec::new();
+
+    for queue in &queues {
+        let qtype = get_str(queue, "type").to_uppercase();
+        if qtype != "QLOCAL" && qtype != "LOCAL" {
+            continue;
+        }
+
+        let current_depth = get_i64(queue, "current_queue_depth");
+        let max_depth = get_i64(queue, "max_queue_depth");
+
+        #[allow(clippy::cast_precision_loss)]
+        let depth_pct = if max_depth > 0 {
+            current_depth as f64 / max_depth as f64 * 100.0
+        } else {
+            0.0
+        };
+
+        results.push(QueueDepthInfo {
+            name: get_str(queue, "queue_name"),
+            current_depth,
+            max_depth,
+            depth_pct,
+            open_input: get_i64(queue, "open_input_count"),
+            open_output: get_i64(queue, "open_output_count"),
+            warning: depth_pct >= threshold_pct,
+        });
+    }
+
+    results.sort_by(|a, b| b.depth_pct.total_cmp(&a.depth_pct));
+    Ok(results)
+}
+
+/// Report channel definitions merged with live channel status.
+pub fn report_channel_status(session: &mut MqRestSession) -> Result<Vec<ChannelInfo>> {
+    let channels = session.display_channel(Some("*"), None, None, None)?;
+    let mut definitions: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    for channel in channels {
+        let cname = get_str(&channel, "channel_name");
+        if !cname.is_empty() {
+            definitions.insert(cname, channel);
+        }
+    }
+
+    let mut live_status: HashMap<String, String> = HashMap::new();
+    if let Ok(statuses) = session.display_chstatus(Some("*"), None, None, None) {
+        for entry in statuses {
+            let cname = get_str(&entry, "channel_name");
+            let cstatus = get_str(&entry, "status");
+            if !cname.is_empty() {
+                live_status.insert(cname, cstatus);
+            }
+        }
+    }
+
+    let mut results: Vec<ChannelInfo> = Vec::new();
+
+    let mut def_names: Vec<&String> = definitions.keys().collect();
+    def_names.sort();
+    for cname in def_names {
+        let defn = &definitions[cname];
+        let ctype = get_str(defn, "channel_type");
+        let conname = get_str(defn, "connection_name");
+        let status = live_status
+            .get(cname)
+            .cloned()
+            .unwrap_or_else(|| "INACTIVE".into());
+
+        results.push(ChannelInfo {
+            name: cname.clone(),
+            channel_type: ctype,
+            connection_name: conname,
+            defined: true,
+            status,
+        });
+    }
+
+    let mut status_names: Vec<&String> = live_status.keys().collect();
+    status_names.sort();
+    for cname in status_names {
+        if !definitions.contains_key(cname) {
+            results.push(ChannelInfo {
+                name: cname.clone(),
+                channel_type: String::new(),
+                connection_name: String::new(),
+                defined: false,
+                status: live_status[cname].clone(),
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+const CRITICAL_DEPTH_PCT: f64 = 90.0;
+
+/// Inspect the dead letter queue configuration and depth.
+pub fn inspect_dlq(session: &mut MqRestSession) -> Result<DlqReport> {
+    let qmgr = session.display_qmgr(None, None)?;
+
+    let dlq_name = qmgr
+        .as_ref()
+        .map(|q| get_str(q, "dead_letter_queue_name"))
+        .unwrap_or_default();
+
+    if dlq_name.is_empty() {
+        return Ok(DlqReport {
+            configured: false,
+            dlq_name: String::new(),
+            current_depth: 0,
+            max_depth: 0,
+            depth_pct: 0.0,
+            open_input: 0,
+            open_output: 0,
+            suggestion: "No dead letter queue configured. Define one with ALTER QMGR DEADQ."
+                .to_string(),
+        });
+    }
+
+    let queues = session.display_queue(Some(&dlq_name), None, None, None)?;
+    if queues.is_empty() {
+        return Ok(DlqReport {
+            configured: true,
+            dlq_name: dlq_name.clone(),
+            current_depth: 0,
+            max_depth: 0,
+            depth_pct: 0.0,
+            open_input: 0,
+            open_output: 0,
+            suggestion: format!("DLQ '{dlq_name}' is configured but the queue does not exist."),
+        });
+    }
+
+    let dlq = &queues[0];
+    let current_depth = get_i64(dlq, "current_queue_depth");
+    let max_depth = get_i64(dlq, "max_queue_depth");
+    let open_input = get_i64(dlq, "open_input_count");
+    let open_output = get_i64(dlq, "open_output_count");
+
+    #[allow(clippy::cast_precision_loss)]
+    let depth_pct = if max_depth > 0 {
+        current_depth as f64 / max_depth as f64 * 100.0
+    } else {
+        0.0
+    };
+
+    let suggestion = if current_depth == 0 {
+        "DLQ is empty. No action needed."
+    } else if depth_pct >= CRITICAL_DEPTH_PCT {
+        "DLQ is near capacity. Investigate and clear undeliverable messages urgently."
+    } else {
+        "DLQ has messages. Investigate undeliverable messages."
+    };
+
+    Ok(DlqReport {
+        configured: true,
+        dlq_name,
+        current_depth,
+        max_depth,
+        depth_pct,
+        open_input,
+        open_output,
+        suggestion: suggestion.to_string(),
+    })
+}
+
+/// Report queue handles from `DISPLAY QSTATUS TYPE(HANDLE)`.
+pub fn report_queue_handles(session: &mut MqRestSession) -> Result<Vec<QueueHandleInfo>> {
+    let mut qstatus_params: HashMap<String, Value> = HashMap::new();
+    qstatus_params.insert("type".into(), Value::String("HANDLE".into()));
+
+    let entries = session
+        .display_qstatus(Some("*"), Some(&qstatus_params), None, None)
+        .unwrap_or_default();
+
+    let results = entries
+        .iter()
+        .map(|entry| QueueHandleInfo {
+            queue_name: get_str(entry, "queue_name"),
+            handle_state: get_str(entry, "handle_state"),
+            connection_id: get_str(entry, "connection_id"),
+            open_options: get_str(entry, "open_options"),
+        })
+        .collect();
+
+    Ok(results)
+}
+
+/// Report connection handles from `DISPLAY CONN TYPE(HANDLE)`.
+pub fn report_connection_handles(session: &mut MqRestSession) -> Result<Vec<ConnectionHandleInfo>> {
+    let mut conn_params: HashMap<String, Value> = HashMap::new();
+    conn_params.insert(
+        "connection_info_type".into(),
+        Value::String("HANDLE".into()),
+    );
+
+    let entries = session
+        .display_conn(Some("*"), Some(&conn_params), None, None)
+        .unwrap_or_default();
+
+    let results = entries
+        .iter()
+        .map(|entry| ConnectionHandleInfo {
+            connection_id: get_str(entry, "connection_id"),
+            object_name: get_str(entry, "object_name"),
+            handle_state: get_str(entry, "handle_state"),
+            object_type: get_str(entry, "object_type"),
+        })
+        .collect();
+
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Provision helpers
+// ---------------------------------------------------------------------------
+
+const PREFIX: &str = "PROV";
+
+enum DefineMethod {
+    Qlocal,
+    Qremote,
+    Channel,
+}
+
+fn define(
+    session: &mut MqRestSession,
+    method: DefineMethod,
+    name: &str,
+    params: &HashMap<String, Value>,
+    created: &mut Vec<String>,
+    failed: &mut Vec<String>,
+) {
+    let label = format!("{}/{name}", session.qmgr_name());
+    let result = match method {
+        DefineMethod::Qlocal => session.define_qlocal(name, Some(params), None),
+        DefineMethod::Qremote => session.define_qremote(name, Some(params), None),
+        DefineMethod::Channel => session.define_channel(name, Some(params), None),
+    };
+    match result {
+        Ok(()) => created.push(label),
+        Err(_) => failed.push(label),
+    }
+}
+
+enum DeleteMethod {
+    Queue,
+    Channel,
+}
+
+fn delete(
+    session: &mut MqRestSession,
+    method: DeleteMethod,
+    name: &str,
+    label: &str,
+    failures: &mut Vec<String>,
+) {
+    let result = match method {
+        DeleteMethod::Queue => session.delete_queue(name, None, None),
+        DeleteMethod::Channel => session.delete_channel(name, None, None),
+    };
+    if result.is_err() {
+        failures.push(format!("{label}/{name}"));
+    }
+}
+
+fn params(entries: &[(&str, &str)]) -> HashMap<String, Value> {
+    entries
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), Value::String((*v).to_string())))
+        .collect()
+}
+
+fn define_queues(
+    qm1: &mut MqRestSession,
+    qm2: &mut MqRestSession,
+    created: &mut Vec<String>,
+    failed: &mut Vec<String>,
+) {
+    define(
+        qm1,
+        DefineMethod::Qlocal,
+        &format!("{PREFIX}.QM1.LOCAL"),
+        &params(&[
+            ("replace", "yes"),
+            ("default_persistence", "yes"),
+            ("description", "provisioned local queue on QM1"),
+        ]),
+        created,
+        failed,
+    );
+    define(
+        qm2,
+        DefineMethod::Qlocal,
+        &format!("{PREFIX}.QM2.LOCAL"),
+        &params(&[
+            ("replace", "yes"),
+            ("default_persistence", "yes"),
+            ("description", "provisioned local queue on QM2"),
+        ]),
+        created,
+        failed,
+    );
+
+    define(
+        qm1,
+        DefineMethod::Qlocal,
+        &format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
+        &params(&[
+            ("replace", "yes"),
+            ("usage", "XMITQ"),
+            ("description", "xmit queue QM1 to QM2"),
+        ]),
+        created,
+        failed,
+    );
+    define(
+        qm2,
+        DefineMethod::Qlocal,
+        &format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
+        &params(&[
+            ("replace", "yes"),
+            ("usage", "XMITQ"),
+            ("description", "xmit queue QM2 to QM1"),
+        ]),
+        created,
+        failed,
+    );
+
+    define(
+        qm1,
+        DefineMethod::Qremote,
+        &format!("{PREFIX}.REMOTE.TO.QM2"),
+        &params(&[
+            ("replace", "yes"),
+            ("remote_queue_name", &format!("{PREFIX}.QM2.LOCAL")),
+            ("remote_queue_manager_name", "QM2"),
+            (
+                "transmission_queue_name",
+                &format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
+            ),
+            ("description", "remote queue QM1 to QM2"),
+        ]),
+        created,
+        failed,
+    );
+    define(
+        qm2,
+        DefineMethod::Qremote,
+        &format!("{PREFIX}.REMOTE.TO.QM1"),
+        &params(&[
+            ("replace", "yes"),
+            ("remote_queue_name", &format!("{PREFIX}.QM1.LOCAL")),
+            ("remote_queue_manager_name", "QM1"),
+            (
+                "transmission_queue_name",
+                &format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
+            ),
+            ("description", "remote queue QM2 to QM1"),
+        ]),
+        created,
+        failed,
+    );
+}
+
+fn define_channels(
+    qm1: &mut MqRestSession,
+    qm2: &mut MqRestSession,
+    created: &mut Vec<String>,
+    failed: &mut Vec<String>,
+) {
+    define(
+        qm1,
+        DefineMethod::Channel,
+        &format!("{PREFIX}.QM1.TO.QM2"),
+        &params(&[
+            ("replace", "yes"),
+            ("channel_type", "SDR"),
+            ("transport_type", "TCP"),
+            ("connection_name", "qm2(1414)"),
+            (
+                "transmission_queue_name",
+                &format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
+            ),
+            ("description", "sender QM1 to QM2"),
+        ]),
+        created,
+        failed,
+    );
+    define(
+        qm2,
+        DefineMethod::Channel,
+        &format!("{PREFIX}.QM1.TO.QM2"),
+        &params(&[
+            ("replace", "yes"),
+            ("channel_type", "RCVR"),
+            ("transport_type", "TCP"),
+            ("description", "receiver QM1 to QM2"),
+        ]),
+        created,
+        failed,
+    );
+    define(
+        qm2,
+        DefineMethod::Channel,
+        &format!("{PREFIX}.QM2.TO.QM1"),
+        &params(&[
+            ("replace", "yes"),
+            ("channel_type", "SDR"),
+            ("transport_type", "TCP"),
+            ("connection_name", "qm1(1414)"),
+            (
+                "transmission_queue_name",
+                &format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
+            ),
+            ("description", "sender QM2 to QM1"),
+        ]),
+        created,
+        failed,
+    );
+    define(
+        qm1,
+        DefineMethod::Channel,
+        &format!("{PREFIX}.QM2.TO.QM1"),
+        &params(&[
+            ("replace", "yes"),
+            ("channel_type", "RCVR"),
+            ("transport_type", "TCP"),
+            ("description", "receiver QM2 to QM1"),
+        ]),
+        created,
+        failed,
+    );
+}
+
+/// Provision queues, channels, and remote queue definitions across two
+/// queue managers.
+pub fn provision(qm1: &mut MqRestSession, qm2: &mut MqRestSession) -> Result<ProvisionResult> {
+    let mut created: Vec<String> = Vec::new();
+    let mut failed: Vec<String> = Vec::new();
+
+    define_queues(qm1, qm2, &mut created, &mut failed);
+    define_channels(qm1, qm2, &mut created, &mut failed);
+
+    let verified = match (
+        qm1.display_queue(Some(&format!("{PREFIX}.*")), None, None, None),
+        qm2.display_queue(Some(&format!("{PREFIX}.*")), None, None, None),
+    ) {
+        (Ok(q1), Ok(q2)) => q1.len() >= 3 && q2.len() >= 3,
+        _ => false,
+    };
+
+    Ok(ProvisionResult {
+        objects_created: created,
+        failures: failed,
+        verified,
+    })
+}
+
+/// Tear down all provisioned objects from both queue managers.
+pub fn teardown(qm1: &mut MqRestSession, qm2: &mut MqRestSession) -> Result<Vec<String>> {
+    let mut failures: Vec<String> = Vec::new();
+
+    let channels = [
+        format!("{PREFIX}.QM1.TO.QM2"),
+        format!("{PREFIX}.QM2.TO.QM1"),
+    ];
+    let queues = [
+        format!("{PREFIX}.REMOTE.TO.QM1"),
+        format!("{PREFIX}.REMOTE.TO.QM2"),
+        format!("{PREFIX}.QM1.TO.QM2.XMITQ"),
+        format!("{PREFIX}.QM2.TO.QM1.XMITQ"),
+        format!("{PREFIX}.QM1.LOCAL"),
+        format!("{PREFIX}.QM2.LOCAL"),
+    ];
+
+    for (session, label) in [(&mut *qm1, "QM1"), (&mut *qm2, "QM2")] {
+        for channel in &channels {
+            delete(
+                session,
+                DeleteMethod::Channel,
+                channel,
+                label,
+                &mut failures,
+            );
+        }
+        for queue in &queues {
+            delete(session, DeleteMethod::Queue, queue, label, &mut failures);
+        }
+    }
+
+    Ok(failures)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::{Value, json};
+
+    use crate::test_helpers::{
+        MockTransport, empty_success_response, mock_session, success_response,
+    };
+
+    use super::*;
+
+    // Helpers ---------------------------------------------------------------
+
+    fn qmgr_response(name: &str) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("queue_manager_name".into(), json!(name));
+        m
+    }
+
+    fn qmstatus_response() -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("ha_status".into(), json!("RUNNING"));
+        m
+    }
+
+    fn cmdserv_response() -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("status".into(), json!("RUNNING"));
+        m
+    }
+
+    fn listener_response(name: &str, mode: &str) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("listener_name".into(), json!(name));
+        m.insert("start_mode".into(), json!(mode));
+        m
+    }
+
+    fn local_queue_response(
+        name: &str,
+        depth: i64,
+        max: i64,
+        open_in: i64,
+        open_out: i64,
+    ) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("queue_name".into(), json!(name));
+        m.insert("type".into(), json!("QLOCAL"));
+        m.insert("current_queue_depth".into(), json!(depth));
+        m.insert("max_queue_depth".into(), json!(max));
+        m.insert("open_input_count".into(), json!(open_in));
+        m.insert("open_output_count".into(), json!(open_out));
+        m
+    }
+
+    fn channel_def_response(name: &str, ctype: &str, conn: &str) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("channel_name".into(), json!(name));
+        m.insert("channel_type".into(), json!(ctype));
+        m.insert("connection_name".into(), json!(conn));
+        m
+    }
+
+    fn chstatus_response(name: &str, status: &str) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("channel_name".into(), json!(name));
+        m.insert("status".into(), json!(status));
+        m
+    }
+
+    fn qmgr_with_dlq(dlq_name: &str) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("dead_letter_queue_name".into(), json!(dlq_name));
+        m
+    }
+
+    fn queue_handle_response(
+        queue: &str,
+        state: &str,
+        conn: &str,
+        opts: &str,
+    ) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("queue_name".into(), json!(queue));
+        m.insert("handle_state".into(), json!(state));
+        m.insert("connection_id".into(), json!(conn));
+        m.insert("open_options".into(), json!(opts));
+        m
+    }
+
+    fn conn_handle_response(
+        conn: &str,
+        obj: &str,
+        state: &str,
+        otype: &str,
+    ) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert("connection_id".into(), json!(conn));
+        m.insert("object_name".into(), json!(obj));
+        m.insert("handle_state".into(), json!(state));
+        m.insert("object_type".into(), json!(otype));
+        m
+    }
+
+    // health_check ----------------------------------------------------------
+
+    #[test]
+    fn health_check_passing() {
+        let transport = MockTransport::new(vec![
+            // display_qmgr
+            success_response(vec![qmgr_response("QM1")]),
+            // display_qmstatus
+            success_response(vec![qmstatus_response()]),
+            // display_cmdserv
+            success_response(vec![cmdserv_response()]),
+            // display_listener
+            success_response(vec![listener_response("LISTENER.TCP", "QMGR")]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let result = check_health(&mut session).expect("check_health failed");
+        assert!(result.reachable);
+        assert!(result.passed);
+        assert_eq!(result.qmgr_name, "QM1");
+        assert_eq!(result.status, "RUNNING");
+        assert_eq!(result.command_server, "RUNNING");
+        assert_eq!(result.listeners.len(), 1);
+        assert_eq!(result.listeners[0].name, "LISTENER.TCP");
+        assert_eq!(result.listeners[0].start_mode, "QMGR");
+    }
+
+    #[test]
+    fn health_check_unreachable() {
+        let transport = MockTransport::new(vec![
+            // display_qmgr fails (command error)
+            crate::test_helpers::error_response(2, 3008),
+        ]);
+        let mut session = mock_session(transport);
+
+        let result = check_health(&mut session).expect("check_health failed");
+        assert!(!result.reachable);
+        assert!(!result.passed);
+        assert_eq!(result.status, "UNKNOWN");
+        assert_eq!(result.command_server, "UNKNOWN");
+        assert!(result.listeners.is_empty());
+    }
+
+    #[test]
+    fn health_check_listener_error() {
+        let transport = MockTransport::new(vec![
+            // display_qmgr succeeds
+            success_response(vec![qmgr_response("QM1")]),
+            // display_qmstatus
+            success_response(vec![qmstatus_response()]),
+            // display_cmdserv
+            success_response(vec![cmdserv_response()]),
+            // display_listener fails
+            crate::test_helpers::error_response(2, 3065),
+        ]);
+        let mut session = mock_session(transport);
+
+        let result = check_health(&mut session).expect("check_health failed");
+        assert!(result.reachable);
+        assert!(result.passed);
+        assert!(result.listeners.is_empty());
+    }
+
+    #[test]
+    fn health_check_no_status_or_cmdserv() {
+        let transport = MockTransport::new(vec![
+            // display_qmgr succeeds
+            success_response(vec![qmgr_response("QM1")]),
+            // display_qmstatus returns empty
+            empty_success_response(),
+            // display_cmdserv returns empty
+            empty_success_response(),
+            // display_listener returns empty
+            empty_success_response(),
+        ]);
+        let mut session = mock_session(transport);
+
+        let result = check_health(&mut session).expect("check_health failed");
+        assert!(result.reachable);
+        assert!(!result.passed); // status stays "UNKNOWN"
+        assert_eq!(result.status, "UNKNOWN");
+        assert_eq!(result.command_server, "UNKNOWN");
+        assert!(result.listeners.is_empty());
+    }
+
+    // monitor_queue_depths --------------------------------------------------
+
+    #[test]
+    fn monitor_queue_depths_basic() {
+        let transport = MockTransport::new(vec![success_response(vec![
+            local_queue_response("Q1", 50, 100, 1, 2),
+            local_queue_response("Q2", 90, 100, 0, 0),
+            // Non-local queue should be filtered out
+            {
+                let mut m = HashMap::new();
+                m.insert("queue_name".into(), json!("REMOTE.Q"));
+                m.insert("type".into(), json!("QREMOTE"));
+                m
+            },
+        ])]);
+        let mut session = mock_session(transport);
+
+        let results =
+            monitor_queue_depths(&mut session, 80.0).expect("monitor_queue_depths failed");
+        assert_eq!(results.len(), 2);
+        // Sorted by depth_pct descending
+        assert_eq!(results[0].name, "Q2");
+        assert!(results[0].warning);
+        assert_eq!(results[1].name, "Q1");
+        assert!(!results[1].warning);
+    }
+
+    #[test]
+    fn monitor_queue_depths_zero_max() {
+        let transport = MockTransport::new(vec![success_response(vec![local_queue_response(
+            "Q1", 0, 0, 0, 0,
+        )])]);
+        let mut session = mock_session(transport);
+
+        let results =
+            monitor_queue_depths(&mut session, 80.0).expect("monitor_queue_depths failed");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].depth_pct, 0.0);
+        assert!(!results[0].warning);
+    }
+
+    // report_channel_status -------------------------------------------------
+
+    #[test]
+    fn channel_status_with_definitions_and_status() {
+        let transport = MockTransport::new(vec![
+            // display_channel
+            success_response(vec![
+                channel_def_response("CHL.A", "SDR", "host(1414)"),
+                channel_def_response("CHL.B", "RCVR", ""),
+            ]),
+            // display_chstatus
+            success_response(vec![
+                chstatus_response("CHL.A", "RUNNING"),
+                chstatus_response("CHL.ORPHAN", "STOPPED"),
+            ]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let results = report_channel_status(&mut session).expect("report_channel_status failed");
+
+        // CHL.A (defined + running), CHL.B (defined + inactive), CHL.ORPHAN (no def)
+        assert_eq!(results.len(), 3);
+
+        let chl_a = results.iter().find(|c| c.name == "CHL.A").unwrap();
+        assert!(chl_a.defined);
+        assert_eq!(chl_a.status, "RUNNING");
+        assert_eq!(chl_a.channel_type, "SDR");
+
+        let chl_b = results.iter().find(|c| c.name == "CHL.B").unwrap();
+        assert!(chl_b.defined);
+        assert_eq!(chl_b.status, "INACTIVE");
+
+        let orphan = results.iter().find(|c| c.name == "CHL.ORPHAN").unwrap();
+        assert!(!orphan.defined);
+        assert_eq!(orphan.status, "STOPPED");
+    }
+
+    #[test]
+    fn channel_status_no_live_status() {
+        let transport = MockTransport::new(vec![
+            // display_channel
+            success_response(vec![channel_def_response("CHL.A", "SVRCONN", "")]),
+            // display_chstatus returns error (no channels running)
+            crate::test_helpers::error_response(2, 3065),
+        ]);
+        let mut session = mock_session(transport);
+
+        let results = report_channel_status(&mut session).expect("report_channel_status failed");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, "INACTIVE");
+    }
+
+    // inspect_dlq -----------------------------------------------------------
+
+    #[test]
+    fn dlq_configured_empty() {
+        let transport = MockTransport::new(vec![
+            // display_qmgr
+            success_response(vec![qmgr_with_dlq("DEAD.LETTER.Q")]),
+            // display_queue (DLQ details)
+            success_response(vec![local_queue_response("DEAD.LETTER.Q", 0, 5000, 0, 0)]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let report = inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert!(report.configured);
+        assert_eq!(report.dlq_name, "DEAD.LETTER.Q");
+        assert_eq!(report.current_depth, 0);
+        assert_eq!(report.suggestion, "DLQ is empty. No action needed.");
+    }
+
+    #[test]
+    fn dlq_not_configured() {
+        let transport = MockTransport::new(vec![
+            // display_qmgr with no DLQ
+            success_response(vec![{
+                let mut m = HashMap::new();
+                m.insert("dead_letter_queue_name".into(), json!(""));
+                m
+            }]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let report = inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert!(!report.configured);
+        assert!(report.dlq_name.is_empty());
+        assert!(
+            report
+                .suggestion
+                .contains("No dead letter queue configured")
+        );
+    }
+
+    #[test]
+    fn dlq_has_messages() {
+        let transport = MockTransport::new(vec![
+            success_response(vec![qmgr_with_dlq("DLQ")]),
+            success_response(vec![local_queue_response("DLQ", 10, 5000, 0, 0)]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let report = inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert!(report.configured);
+        assert_eq!(report.current_depth, 10);
+        assert!(report.suggestion.contains("DLQ has messages"));
+    }
+
+    #[test]
+    fn dlq_near_capacity() {
+        let transport = MockTransport::new(vec![
+            success_response(vec![qmgr_with_dlq("DLQ")]),
+            success_response(vec![local_queue_response("DLQ", 950, 1000, 0, 0)]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let report = inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert!(report.depth_pct >= 90.0);
+        assert!(report.suggestion.contains("near capacity"));
+    }
+
+    #[test]
+    fn dlq_queue_does_not_exist() {
+        let transport = MockTransport::new(vec![
+            success_response(vec![qmgr_with_dlq("MISSING.DLQ")]),
+            // display_queue returns empty
+            empty_success_response(),
+        ]);
+        let mut session = mock_session(transport);
+
+        let report = inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert!(report.configured);
+        assert!(report.suggestion.contains("does not exist"));
+    }
+
+    #[test]
+    fn dlq_zero_max_depth() {
+        let transport = MockTransport::new(vec![
+            success_response(vec![qmgr_with_dlq("DLQ")]),
+            success_response(vec![local_queue_response("DLQ", 0, 0, 0, 0)]),
+        ]);
+        let mut session = mock_session(transport);
+
+        let report = inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert_eq!(report.depth_pct, 0.0);
+    }
+
+    // report_queue_handles --------------------------------------------------
+
+    #[test]
+    fn queue_handles_with_results() {
+        let transport = MockTransport::new(vec![success_response(vec![queue_handle_response(
+            "Q1", "ACTIVE", "CONN1", "INPUT",
+        )])]);
+        let mut session = mock_session(transport);
+
+        let results = report_queue_handles(&mut session).expect("report_queue_handles failed");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].queue_name, "Q1");
+        assert_eq!(results[0].handle_state, "ACTIVE");
+    }
+
+    #[test]
+    fn queue_handles_empty() {
+        let transport = MockTransport::new(vec![
+            // display_qstatus returns error (no handles)
+            crate::test_helpers::error_response(2, 3065),
+        ]);
+        let mut session = mock_session(transport);
+
+        let results = report_queue_handles(&mut session).expect("report_queue_handles failed");
+        assert!(results.is_empty());
+    }
+
+    // report_connection_handles ---------------------------------------------
+
+    #[test]
+    fn connection_handles_with_results() {
+        let transport = MockTransport::new(vec![success_response(vec![conn_handle_response(
+            "CONN1", "Q1", "ACTIVE", "QUEUE",
+        )])]);
+        let mut session = mock_session(transport);
+
+        let results =
+            report_connection_handles(&mut session).expect("report_connection_handles failed");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].connection_id, "CONN1");
+        assert_eq!(results[0].object_name, "Q1");
+    }
+
+    #[test]
+    fn connection_handles_empty() {
+        let transport = MockTransport::new(vec![crate::test_helpers::error_response(2, 3065)]);
+        let mut session = mock_session(transport);
+
+        let results =
+            report_connection_handles(&mut session).expect("report_connection_handles failed");
+        assert!(results.is_empty());
+    }
+
+    // provision + teardown --------------------------------------------------
+
+    #[test]
+    fn provision_succeeds() {
+        // provision calls: 6 defines (queues) + 4 defines (channels) + 2 verify queries
+        let mut responses = Vec::new();
+
+        // 10 define calls — all succeed
+        for _ in 0..10 {
+            responses.push(empty_success_response());
+        }
+
+        // verification: display_queue on QM1
+        responses.push(success_response(vec![
+            local_queue_response("PROV.QM1.LOCAL", 0, 5000, 0, 0),
+            local_queue_response("PROV.QM1.TO.QM2.XMITQ", 0, 5000, 0, 0),
+            local_queue_response("PROV.REMOTE.TO.QM2", 0, 5000, 0, 0),
+        ]));
+        // verification: display_queue on QM2
+        responses.push(success_response(vec![
+            local_queue_response("PROV.QM2.LOCAL", 0, 5000, 0, 0),
+            local_queue_response("PROV.QM2.TO.QM1.XMITQ", 0, 5000, 0, 0),
+            local_queue_response("PROV.REMOTE.TO.QM1", 0, 5000, 0, 0),
+        ]));
+
+        // Split responses: odd-indexed go to QM2, even-indexed to QM1.
+        // Actually, provision calls define_queues then define_channels with
+        // alternating QM1/QM2 calls. Let me build two separate transports.
+        // The order is:
+        //   define_queues: qm1, qm2, qm1, qm2, qm1, qm2 (6 calls)
+        //   define_channels: qm1, qm2, qm2, qm1 (4 calls)
+        //   verify: qm1, qm2 (2 calls)
+        // QM1 gets calls at indices: 0, 2, 4, 6, 9, 10 (6 calls)
+        // QM2 gets calls at indices: 1, 3, 5, 7, 8, 11 (6 calls)
+
+        let qm1_responses = vec![
+            empty_success_response(), // define qm1 local
+            empty_success_response(), // define qm1 xmitq
+            empty_success_response(), // define qm1 remote
+            empty_success_response(), // define qm1 channel sdr
+            empty_success_response(), // define qm1 channel rcvr
+            // verify qm1
+            success_response(vec![
+                local_queue_response("PROV.QM1.LOCAL", 0, 5000, 0, 0),
+                local_queue_response("PROV.QM1.TO.QM2.XMITQ", 0, 5000, 0, 0),
+                local_queue_response("PROV.REMOTE.TO.QM2", 0, 5000, 0, 0),
+            ]),
+        ];
+
+        let qm2_responses = vec![
+            empty_success_response(), // define qm2 local
+            empty_success_response(), // define qm2 xmitq
+            empty_success_response(), // define qm2 remote
+            empty_success_response(), // define qm2 channel rcvr
+            empty_success_response(), // define qm2 channel sdr
+            // verify qm2
+            success_response(vec![
+                local_queue_response("PROV.QM2.LOCAL", 0, 5000, 0, 0),
+                local_queue_response("PROV.QM2.TO.QM1.XMITQ", 0, 5000, 0, 0),
+                local_queue_response("PROV.REMOTE.TO.QM1", 0, 5000, 0, 0),
+            ]),
+        ];
+
+        let transport1 = MockTransport::new(qm1_responses);
+        let transport2 = MockTransport::new(qm2_responses);
+        let mut qm1 = mock_session(transport1);
+        let mut qm2 = mock_session(transport2);
+
+        let result = provision(&mut qm1, &mut qm2).expect("provision failed");
+        assert_eq!(result.objects_created.len(), 10);
+        assert!(result.failures.is_empty());
+        assert!(result.verified);
+    }
+
+    #[test]
+    fn provision_with_failures() {
+        // All calls fail
+        let qm1_responses = vec![
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            // verification still runs
+            empty_success_response(),
+        ];
+        let qm2_responses = vec![
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            crate::test_helpers::error_response(2, 3000),
+            empty_success_response(),
+        ];
+
+        let mut qm1 = mock_session(MockTransport::new(qm1_responses));
+        let mut qm2 = mock_session(MockTransport::new(qm2_responses));
+
+        let result = provision(&mut qm1, &mut qm2).expect("provision failed");
+        assert!(result.objects_created.is_empty());
+        assert_eq!(result.failures.len(), 10);
+        assert!(!result.verified);
+    }
+
+    #[test]
+    fn provision_verification_transport_error() {
+        // All defines succeed, but verification calls exhaust the transport
+        let mut qm1_responses = Vec::new();
+        for _ in 0..5 {
+            qm1_responses.push(empty_success_response());
+        }
+        // QM1 verification returns error (transport exhausted)
+
+        let mut qm2_responses = Vec::new();
+        for _ in 0..5 {
+            qm2_responses.push(empty_success_response());
+        }
+        // QM2 verification: no response queued — will error
+
+        let mut qm1 = mock_session(MockTransport::new(qm1_responses));
+        let mut qm2 = mock_session(MockTransport::new(qm2_responses));
+
+        let result = provision(&mut qm1, &mut qm2).expect("provision failed");
+        assert!(!result.verified);
+    }
+
+    #[test]
+    fn teardown_succeeds() {
+        // teardown calls: 2 channels + 6 queues per session = 8 per QM, 16 total
+        let qm1_responses: Vec<_> = (0..8).map(|_| empty_success_response()).collect();
+        let qm2_responses: Vec<_> = (0..8).map(|_| empty_success_response()).collect();
+
+        let mut qm1 = mock_session(MockTransport::new(qm1_responses));
+        let mut qm2 = mock_session(MockTransport::new(qm2_responses));
+
+        let failures = teardown(&mut qm1, &mut qm2).expect("teardown failed");
+        assert!(failures.is_empty());
+    }
+
+    #[test]
+    fn teardown_with_failures() {
+        let qm1_responses: Vec<_> = (0..8)
+            .map(|_| crate::test_helpers::error_response(2, 3000))
+            .collect();
+        let qm2_responses: Vec<_> = (0..8)
+            .map(|_| crate::test_helpers::error_response(2, 3000))
+            .collect();
+
+        let mut qm1 = mock_session(MockTransport::new(qm1_responses));
+        let mut qm2 = mock_session(MockTransport::new(qm2_responses));
+
+        let failures = teardown(&mut qm1, &mut qm2).expect("teardown failed");
+        assert_eq!(failures.len(), 16);
+    }
+
+    // get_str / get_i64 helpers ---------------------------------------------
+
+    #[test]
+    fn get_str_missing_key() {
+        let m: HashMap<String, Value> = HashMap::new();
+        assert_eq!(super::get_str(&m, "missing"), "");
+    }
+
+    #[test]
+    fn get_str_non_string() {
+        let mut m = HashMap::new();
+        m.insert("num".into(), json!(42));
+        assert_eq!(super::get_str(&m, "num"), "");
+    }
+
+    #[test]
+    fn get_str_trimmed() {
+        let mut m = HashMap::new();
+        m.insert("val".into(), json!("  hello  "));
+        assert_eq!(super::get_str(&m, "val"), "hello");
+    }
+
+    #[test]
+    fn get_i64_from_number() {
+        let mut m = HashMap::new();
+        m.insert("val".into(), json!(42));
+        assert_eq!(super::get_i64(&m, "val"), 42);
+    }
+
+    #[test]
+    fn get_i64_from_string() {
+        let mut m = HashMap::new();
+        m.insert("val".into(), json!("  99  "));
+        assert_eq!(super::get_i64(&m, "val"), 99);
+    }
+
+    #[test]
+    fn get_i64_from_invalid_string() {
+        let mut m = HashMap::new();
+        m.insert("val".into(), json!("abc"));
+        assert_eq!(super::get_i64(&m, "val"), 0);
+    }
+
+    #[test]
+    fn get_i64_missing_key() {
+        let m: HashMap<String, Value> = HashMap::new();
+        assert_eq!(super::get_i64(&m, "missing"), 0);
+    }
+
+    #[test]
+    fn get_i64_null_value() {
+        let mut m = HashMap::new();
+        m.insert("val".into(), Value::Null);
+        assert_eq!(super::get_i64(&m, "val"), 0);
+    }
+
+    #[test]
+    fn get_i64_float_number() {
+        let mut m = HashMap::new();
+        m.insert("val".into(), json!(3.14));
+        // as_i64() returns None for floats
+        assert_eq!(super::get_i64(&m, "val"), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,8 @@ pub use session::{MqRestSession, MqRestSessionBuilder};
 pub use sync_ops::{SyncConfig, SyncOperation, SyncResult};
 pub use transport::{MqRestTransport, ReqwestTransport, TransportResponse};
 
+#[cfg(feature = "examples")]
+pub mod examples;
+
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1026,3 +1026,122 @@ fn gateway_session_properties() {
     assert_eq!(session.qmgr_name(), config.qm2_qmgr_name);
     assert_eq!(session.gateway_qmgr(), Some(config.qmgr_name.as_str()));
 }
+
+// ---------------------------------------------------------------------------
+// Example function integration tests
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "examples")]
+mod example_tests {
+    use super::*;
+    use mq_rest_admin::examples;
+
+    fn build_qm2_session(config: &IntegrationConfig) -> MqRestSession {
+        MqRestSession::builder(
+            &config.qm2_rest_base_url,
+            &config.qm2_qmgr_name,
+            Credentials::Basic {
+                username: config.admin_user.clone(),
+                password: config.admin_password.clone(),
+            },
+        )
+        .verify_tls(false)
+        .build()
+        .expect("failed to build QM2 session")
+    }
+
+    #[test]
+    fn health_check_qm1() {
+        let config = load_config();
+        let mut session = build_session(&config);
+
+        let result = examples::check_health(&mut session).expect("check_health failed");
+        assert!(result.reachable);
+        assert!(result.passed);
+        assert_eq!(result.qmgr_name, config.qmgr_name);
+    }
+
+    #[test]
+    fn health_check_qm2() {
+        let config = load_config();
+        let mut session = build_qm2_session(&config);
+
+        let result = examples::check_health(&mut session).expect("check_health failed");
+        assert!(result.reachable);
+        assert!(result.passed);
+        assert_eq!(result.qmgr_name, config.qm2_qmgr_name);
+    }
+
+    #[test]
+    fn queue_depth_monitor() {
+        let config = load_config();
+        let mut session = build_session(&config);
+
+        let results = examples::monitor_queue_depths(&mut session, 80.0).expect("monitor failed");
+        assert!(!results.is_empty(), "should return at least one queue");
+        assert!(
+            results.iter().any(|q| q.name == "DEV.QLOCAL"),
+            "should contain DEV.QLOCAL"
+        );
+    }
+
+    #[test]
+    fn channel_status_report() {
+        let config = load_config();
+        let mut session = build_session(&config);
+
+        let results = examples::report_channel_status(&mut session).expect("channel status failed");
+        assert!(!results.is_empty(), "should return at least one channel");
+        assert!(
+            results.iter().any(|c| c.name == "DEV.SVRCONN"),
+            "should contain DEV.SVRCONN"
+        );
+    }
+
+    #[test]
+    fn dlq_inspector() {
+        let config = load_config();
+        let mut session = build_session(&config);
+
+        let report = examples::inspect_dlq(&mut session).expect("inspect_dlq failed");
+        assert!(report.configured);
+        assert_eq!(report.dlq_name, "DEV.DEAD.LETTER");
+        assert_eq!(report.current_depth, 0);
+    }
+
+    #[test]
+    fn queue_status_handles() {
+        let config = load_config();
+        let mut session = build_session(&config);
+
+        let _results = examples::report_queue_handles(&mut session).expect("queue handles failed");
+        // May be empty if no handles are open — just assert it succeeds
+    }
+
+    #[test]
+    fn connection_handles() {
+        let config = load_config();
+        let mut session = build_session(&config);
+
+        let _results =
+            examples::report_connection_handles(&mut session).expect("connection handles failed");
+        // May be empty — just assert it succeeds
+    }
+
+    #[test]
+    fn provision_and_teardown() {
+        let config = load_config();
+        let mut qm1 = build_session(&config);
+        let mut qm2 = build_qm2_session(&config);
+
+        let result = examples::provision(&mut qm1, &mut qm2).expect("provision failed");
+        assert!(
+            !result.objects_created.is_empty(),
+            "should create at least one object"
+        );
+        assert!(result.verified, "verification should pass");
+
+        let failures = examples::teardown(&mut qm1, &mut qm2).expect("teardown failed");
+        assert!(failures.is_empty(), "teardown should have no failures");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary

- Refactor examples to dual-mode with importable functions, tests, and coverage

## Issue Linkage

- Fixes #21

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -