### PR TITLE
chore(ports): assign unique port range for Rust repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,13 +160,20 @@ git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../
 Container details:
 
 - Queue managers: `QM1` and `QM2`
-- QM1 ports: `1414` (MQ listener), `9443` (mqweb console + REST API)
-- QM2 ports: `1415` (MQ listener), `9444` (mqweb console + REST API)
+- QM1 ports: `1454` (MQ listener), `9483` (mqweb console + REST API)
+- QM2 ports: `1455` (MQ listener), `9484` (mqweb console + REST API)
 - Admin credentials: `mqadmin` / `mqadmin`
 - Read-only credentials: `mqreader` / `mqreader`
-- QM1 REST base URL: `https://localhost:9443/ibmmq/rest/v2`
-- QM2 REST base URL: `https://localhost:9444/ibmmq/rest/v2`
+- QM1 REST base URL: `https://localhost:9483/ibmmq/rest/v2`
+- QM2 REST base URL: `https://localhost:9484/ibmmq/rest/v2`
 - Object prefix: `DEV.*`
+
+Port assignments are explicit in each `scripts/dev/mq_*.sh` script via
+`QM1_REST_PORT`, `QM2_REST_PORT`, `QM1_MQ_PORT`, and `QM2_MQ_PORT` exports.
+Rust uses offset ports (9483/9484, 1454/1455) to avoid conflicts with other
+language repos. See the
+[port allocation table](https://github.com/wphillipmoore/mq-rest-admin-common)
+in mq-rest-admin-common for the full cross-language map.
 
 ## Architecture
 

--- a/docs/site/docs/development/local-mq-container.md
+++ b/docs/site/docs/development/local-mq-container.md
@@ -20,8 +20,8 @@ queue managers.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `MQ_REST_BASE_URL` | `https://localhost:9443/ibmmq/rest/v2` | QM1 REST API base URL |
-| `MQ_REST_BASE_URL_QM2` | `https://localhost:9444/ibmmq/rest/v2` | QM2 REST API base URL |
+| `MQ_REST_BASE_URL` | `https://localhost:9483/ibmmq/rest/v2` | QM1 REST API base URL |
+| `MQ_REST_BASE_URL_QM2` | `https://localhost:9484/ibmmq/rest/v2` | QM2 REST API base URL |
 | `MQ_ADMIN_USER` | `mqadmin` | Admin username |
 | `MQ_ADMIN_PASSWORD` | `mqadmin` | Admin password |
 | `MQ_IMAGE` | `icr.io/ibm-messaging/mq:latest` | Container image |
@@ -33,7 +33,7 @@ use mq_rest_admin::{MqRestSession, Credentials};
 
 // Route commands to QM2 through QM1
 let session = MqRestSession::builder()
-    .rest_base_url("https://localhost:9443/ibmmq/rest/v2")
+    .rest_base_url("https://localhost:9483/ibmmq/rest/v2")
     .qmgr_name("QM2")
     .credentials(Credentials::Basic {
         username: "mqadmin".into(),

--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -13,7 +13,7 @@ Start the local MQ development environment before running examples:
 ./scripts/dev/mq_seed.sh
 ```
 
-This starts two queue managers (`QM1` on port 9443, `QM2` on port 9444) on a
+This starts two queue managers (`QM1` on port 9483, `QM2` on port 9484) on a
 shared Docker network. See [local MQ container](development/local-mq-container.md) for details.
 
 ## Environment variables
@@ -23,11 +23,11 @@ defaults:
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `MQ_REST_BASE_URL` | `https://localhost:9443/ibmmq/rest/v2` | QM1 REST endpoint |
+| `MQ_REST_BASE_URL` | `https://localhost:9483/ibmmq/rest/v2` | QM1 REST endpoint |
 | `MQ_QMGR_NAME` | `QM1` | Queue manager name |
 | `MQ_ADMIN_USER` | `mqadmin` | Admin username |
 | `MQ_ADMIN_PASSWORD` | `mqadmin` | Admin password |
-| `MQ_REST_BASE_URL_QM2` | `https://localhost:9444/ibmmq/rest/v2` | QM2 REST endpoint (multi-QM examples) |
+| `MQ_REST_BASE_URL_QM2` | `https://localhost:9484/ibmmq/rest/v2` | QM2 REST endpoint (multi-QM examples) |
 | `DEPTH_THRESHOLD_PCT` | `80` | Warning threshold for queue depth monitor |
 
 ## Running examples

--- a/examples/channel_status.rs
+++ b/examples/channel_status.rs
@@ -13,7 +13,7 @@ use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
-        .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into());
     let qmgr_name = env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into());
     let username = env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into());
     let password = env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into());

--- a/examples/dlq_inspector.rs
+++ b/examples/dlq_inspector.rs
@@ -14,7 +14,7 @@ use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
-        .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into());
     let qmgr_name = env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into());
     let username = env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into());
     let password = env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into());

--- a/examples/health_check.rs
+++ b/examples/health_check.rs
@@ -16,7 +16,7 @@ use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
-        .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into());
     let qmgr_name = env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into());
     let username = env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into());
     let password = env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into());

--- a/examples/provision_environment.rs
+++ b/examples/provision_environment.rs
@@ -9,7 +9,7 @@
 //! ```
 //!
 //! Requires both QM1 and QM2 to be running. Set `MQ_REST_BASE_URL_QM2`
-//! to the QM2 REST endpoint (default: `https://localhost:9444/ibmmq/rest/v2`).
+//! to the QM2 REST endpoint (default: `https://localhost:9484/ibmmq/rest/v2`).
 
 use std::env;
 
@@ -20,9 +20,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let password = env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into());
 
     let qm1_url = env::var("MQ_REST_BASE_URL")
-        .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into());
     let qm2_url = env::var("MQ_REST_BASE_URL_QM2")
-        .unwrap_or_else(|_| "https://localhost:9444/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9484/ibmmq/rest/v2".into());
 
     let mut qm1 = MqRestSession::builder(
         &qm1_url,

--- a/examples/queue_depth_monitor.rs
+++ b/examples/queue_depth_monitor.rs
@@ -15,7 +15,7 @@ use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
-        .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into());
     let qmgr_name = env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into());
     let username = env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into());
     let password = env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into());

--- a/examples/queue_status.rs
+++ b/examples/queue_status.rs
@@ -15,7 +15,7 @@ use mq_rest_admin::{Credentials, MqRestSession, examples};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rest_base_url = env::var("MQ_REST_BASE_URL")
-        .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into());
+        .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into());
     let qmgr_name = env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into());
     let username = env::var("MQ_ADMIN_USER").unwrap_or_else(|_| "mqadmin".into());
     let password = env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| "mqadmin".into());

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME="mqrest-rust"
+export QM1_REST_PORT=9483
+export QM2_REST_PORT=9484
+export QM1_MQ_PORT=1454
+export QM2_MQ_PORT=1455
 
 cd "$mq_dev_env"
 exec scripts/mq_reset.sh

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME="mqrest-rust"
+export QM1_REST_PORT=9483
+export QM2_REST_PORT=9484
+export QM1_MQ_PORT=1454
+export QM2_MQ_PORT=1455
 
 cd "$mq_dev_env"
 exec scripts/mq_seed.sh

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME="mqrest-rust"
+export QM1_REST_PORT=9483
+export QM2_REST_PORT=9484
+export QM1_MQ_PORT=1454
+export QM2_MQ_PORT=1455
 
 cd "$mq_dev_env"
 exec scripts/mq_start.sh

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME="mqrest-rust"
+export QM1_REST_PORT=9483
+export QM2_REST_PORT=9484
+export QM1_MQ_PORT=1454
+export QM2_MQ_PORT=1455
 
 cd "$mq_dev_env"
 exec scripts/mq_stop.sh

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME="mqrest-rust"
+export QM1_REST_PORT=9483
+export QM2_REST_PORT=9484
+export QM1_MQ_PORT=1454
+export QM2_MQ_PORT=1455
 
 cd "$mq_dev_env"
 exec scripts/mq_verify.sh

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -72,12 +72,12 @@ fn load_config() -> IntegrationConfig {
     let default_identity = MQ_DEV_ADMIN_IDENTITY.to_owned();
     IntegrationConfig {
         rest_base_url: env::var("MQ_REST_BASE_URL")
-            .unwrap_or_else(|_| "https://localhost:9443/ibmmq/rest/v2".into()),
+            .unwrap_or_else(|_| "https://localhost:9483/ibmmq/rest/v2".into()),
         admin_user: env::var("MQ_ADMIN_USER").unwrap_or_else(|_| default_identity.clone()),
         admin_password: env::var("MQ_ADMIN_PASSWORD").unwrap_or_else(|_| default_identity),
         qmgr_name: env::var("MQ_QMGR_NAME").unwrap_or_else(|_| "QM1".into()),
         qm2_rest_base_url: env::var("MQ_REST_BASE_URL_QM2")
-            .unwrap_or_else(|_| "https://localhost:9444/ibmmq/rest/v2".into()),
+            .unwrap_or_else(|_| "https://localhost:9484/ibmmq/rest/v2".into()),
         qm2_qmgr_name: env::var("MQ_QMGR_NAME_QM2").unwrap_or_else(|_| "QM2".into()),
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary

- Assign unique port range (9483/9484) and normalize CI ports from 19xxx/11xxx to standard 94xx/14xx pattern

## Issue Linkage

- Fixes #25

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -