### PR TITLE
chore: add build provenance attestation step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,12 @@ jobs:
         if: steps.tag_check.outputs.exists == 'false'
         run: cargo build --release
 
+      - name: Attest build provenance
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "target/release/libmq_rest_admin*"
+
       - name: Generate SBOM
         if: steps.tag_check.outputs.exists == 'false'
         uses: wphillipmoore/standard-actions/actions/security/trivy@develop


### PR DESCRIPTION
# Pull Request

## Summary

- Add actions/attest-build-provenance@v3 step to publish workflow, matching Python/Java/Ruby pattern

## Issue Linkage

- Fixes #34

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -