### PR TITLE
chore: realign CI port range with ecosystem convention

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -20,6 +20,6 @@ jobs:
       security-events: write
     with:
       rust-versions: '["1.93"]'
-      integration-matrix: '[{"rust-version":"1.93","project-suffix":"1-93","qm1-rest-port":"19485","qm2-rest-port":"19486","qm1-mq-port":"11456","qm2-mq-port":"11457"}]'
+      integration-matrix: '[{"rust-version":"1.93","project-suffix":"1-93","qm1-rest-port":"9487","qm2-rest-port":"9488","qm1-mq-port":"1458","qm2-mq-port":"1459"}]'
       run-security: "false"
       run-release-gates: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.integration-matrix || '[{"rust-version":"1.92","project-suffix":"1-92","qm1-rest-port":"19483","qm2-rest-port":"19484","qm1-mq-port":"11454","qm2-mq-port":"11455"},{"rust-version":"1.93","project-suffix":"1-93","qm1-rest-port":"19485","qm2-rest-port":"19486","qm1-mq-port":"11456","qm2-mq-port":"11457"}]') }}
+        include: ${{ fromJSON(inputs.integration-matrix || '[{"rust-version":"1.92","project-suffix":"1-92","qm1-rest-port":"9485","qm2-rest-port":"9486","qm1-mq-port":"1456","qm2-mq-port":"1457"},{"rust-version":"1.93","project-suffix":"1-93","qm1-rest-port":"9487","qm2-rest-port":"9488","qm1-mq-port":"1458","qm2-mq-port":"1459"}]') }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Pull Request

## Summary

- Normalize CI ports from 19xxx/11xxx to canonical 9xxx/1xxx range per ecosystem convention

## Issue Linkage

- Ref #25
- Ref #35

## Testing

- markdownlint
- `validate-local-rust`

## Notes

-
