### PR TITLE
test: add session state populated after command integration test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1035,7 +1035,9 @@ fn session_state_populated_after_command() {
     let config = load_config();
     let mut session = build_session(&config);
 
-    session.display_qmgr().expect("display_qmgr failed");
+    session
+        .display_qmgr(None, None)
+        .expect("display_qmgr failed");
 
     assert!(
         session.last_http_status.is_some(),


### PR DESCRIPTION
# Pull Request

## Summary

- Add integration test verifying session state properties are populated after executing a command

## Issue Linkage

- Ref #136

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -