### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "mq-rest-admin"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mq-rest-admin"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Rust wrapper for the IBM MQ administrative REST API"


### PR DESCRIPTION
# Pull Request

## Summary

- Manual version bump to 1.2.1 to recover from partially-failed v1.2.0 publish

## Issue Linkage

- Ref #45

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -