### PR TITLE
fix: move crates.io publish before SBOM generation and bump to 1.2.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,12 @@ jobs:
         with:
           subject-path: "target/release/libmq_rest_admin*"
 
+      - name: Publish to crates.io
+        if: steps.crates_check.outputs.status == 'not_found'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
       - name: Generate SBOM
         if: steps.tag_check.outputs.exists == 'false'
         uses: wphillipmoore/standard-actions/actions/security/trivy@develop
@@ -94,12 +100,6 @@ jobs:
 
             - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-rust/)
           release-artifacts: dist/*
-
-      - name: Publish to crates.io
-        if: steps.crates_check.outputs.status == 'not_found'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
 
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "mq-rest-admin"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mq-rest-admin"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 rust-version = "1.92"
 description = "Rust wrapper for the IBM MQ administrative REST API"


### PR DESCRIPTION
# Pull Request

## Summary

- Fix SBOM ordering: move crates.io publish before SBOM generation to avoid dirty working tree, and bump version to 1.2.2

## Issue Linkage

- Fixes #45

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -