### PR TITLE
chore: fix develop-version-command and bump to 1.2.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,6 @@ jobs:
           version-regex: '^(version\s*=\s*").*("\s*)$'
           version-replacement: '\g<1>{version}\2'
           version-regex-multiline: "true"
-          develop-version-command: grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml
+          develop-version-command: grep -oP '^version\s*=\s*"\K[^"]+'
           extra-files: Cargo.lock
           app-token: ${{ steps.app-token.outputs.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "mq-rest-admin"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "base64",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mq-rest-admin"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2024"
 rust-version = "1.92"
 description = "Rust wrapper for the IBM MQ administrative REST API"


### PR DESCRIPTION
# Pull Request

## Summary

- Fix develop-version-command SIGPIPE and bump version to 1.2.3

## Issue Linkage

- Fixes #45

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -