### PR TITLE
chore(plugins): install standard-tooling plugin via marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "standard-tooling-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "wphillipmoore/standard-tooling-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "standard-tooling@standard-tooling-marketplace": true
+  }
+}


### PR DESCRIPTION
# Pull Request

## Summary

- Install standard-tooling plugin via marketplace configuration

## Issue Linkage

- Fixes #54

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -
