### PR TITLE
chore: add .markdownlintignore for auto-generated files

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+releases/


### PR DESCRIPTION
# Pull Request

## Summary

- Add .markdownlintignore to exclude CHANGELOG.md and releases/ from markdownlint scope

## Issue Linkage

- Ref wphillipmoore/mq-rest-admin-common#190

## Testing

- markdownlint

## Notes

- Part of cross-repo rollout across all managed repositories