### PR TITLE
chore(docs): strip CLAUDE.md boilerplate now covered by plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,6 @@ translation between Rust idioms and native MQSC parameter names.
 
 **Status**: Pre-alpha (initial setup)
 
-**Canonical Standards**: This repository follows standards at <https://github.com/wphillipmoore/standards-and-conventions> (local path: `../standards-and-conventions` if available)
-
 ## Development Commands
 
 ### Standard Tooling


### PR DESCRIPTION
# Pull Request

## Summary

- Strip CLAUDE.md boilerplate sections now enforced by standard-tooling plugin

## Issue Linkage

- Fixes #56

## Testing

- markdownlint
- `validate-local-rust`

## Notes

- -