### PR TITLE
refactor: migrate publish workflow to shared reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,113 +11,46 @@ permissions:
   id-token: write
   pull-requests: write
 
-concurrency:
-  group: publish
-  cancel-in-progress: false
-
 jobs:
   publish:
-    name: "publish: release"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: write
+    with:
+      ecosystem: rust
+      version-command: >-
+        grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml
+      registry-check-command: >-
+        status_code=$(curl -s -o /dev/null -w "%{http_code}"
+        "https://crates.io/api/v1/crates/mq-rest-admin/$VERSION");
+        if [ "$status_code" = "200" ]; then echo "exists"; else echo "not_found"; fi
+      build-command: cargo build --release
+      attestation-subject-path: "target/release/libmq_rest_admin*"
+      sbom-output-file: "dist/mq-rest-admin-$VERSION.cdx.json"
+      registry-publish-command: cargo publish
+      release-title: mq-rest-admin
+      release-notes: |
+        ## Installation
 
-      - name: Extract version
-        id: version
-        run: |
-          version=$(grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+        ```bash
+        cargo add mq-rest-admin
+        ```
 
-      - name: Check if version already on crates.io
-        id: crates_check
-        run: |
-          status_code=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://crates.io/api/v1/crates/mq-rest-admin/${{ steps.version.outputs.version }}")
-          if [ "$status_code" = "200" ]; then
-            echo "status=exists" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=not_found" >> "$GITHUB_OUTPUT"
-          fi
+        ## Links
 
-      - name: Check if tag already exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Rust
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: "1.93"
-
-      - name: Build release
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          cargo build --release
-          mkdir -p dist
-
-      - name: Attest build provenance
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: "target/release/libmq_rest_admin*"
-
-      - name: Publish to crates.io
-        if: steps.crates_check.outputs.status == 'not_found'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
-
-      - name: Generate SBOM
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
-        with:
-          scan-type: sbom
-          output-file: "dist/mq-rest-admin-${{ steps.version.outputs.version }}.cdx.json"
-
-      - name: Tag and release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
-        with:
-          version: ${{ steps.version.outputs.version }}
-          release-title: "mq-rest-admin"
-          release-notes: |
-            ## Installation
-
-            ```bash
-            cargo add mq-rest-admin
-            ```
-
-            ## Links
-
-            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-rust/)
-          release-artifacts: dist/*
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          version-file: "Cargo.toml"
-          version-regex: '^(version\s*=\s*").*("\s*)$'
-          version-replacement: '\g<1>{version}\2'
-          version-regex-multiline: "true"
-          develop-version-command: grep -oP '^version\s*=\s*"\K[^"]+'
-          extra-files: Cargo.lock
-          app-token: ${{ steps.app-token.outputs.token }}
+        - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-rust/)
+      release-artifacts: "dist/*"
+      version-file: Cargo.toml
+      version-regex: '^(version\s*=\s*").*("\s*)$'
+      version-replacement: '\g<1>{version}\2'
+      version-regex-multiline: "true"
+      develop-version-command: >-
+        grep -oP '^version\s*=\s*"\K[^"]+'
+      extra-files: Cargo.lock
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,4 @@
 CHANGELOG.md
 releases/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Replace per-repo publish.yml with thin caller that delegates to the shared `publish-release.yml` reusable workflow in standard-actions
- All ecosystem-specific behavior is passed as inputs to the shared workflow
- Consistent action refs, step ordering, and SBOM output normalization

Ref wphillipmoore/standard-actions#171

## Test plan

- [ ] Verify CI passes on this branch
- [ ] After standard-actions#171 merges to develop, verify publish workflow runs correctly on next release
- [ ] Confirm idempotency: re-run on existing tag should skip all mutating steps
