### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,23 +18,15 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Install mkdocs and mike
-        run: pip install mkdocs-material mike
-
       - name: Deploy docs
         uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
           version-command: grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml | cut -d. -f1,2
-          mike-command: mike
           checkout-common: "true"


### PR DESCRIPTION
# Pull Request

## Summary

- Run docs workflow inside ghcr.io/wphillipmoore/dev-docs:latest
- Remove manual Python setup and pip install mkdocs-material mike steps

## Issue Linkage

- Fixes #67

## Testing

- markdownlint
- ci: docs workflow passes with container

## Notes

- Merge after standard-tooling-docker#27 and standard-actions#174
