### PR TITLE
fix(ci): specify language, container-tag, and registry-publish in publish-release caller

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,4 +13,8 @@ permissions:
 jobs:
   publish:
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    with:
+      language: rust
+      container-tag: "1.93"
+      registry-publish: true
     secrets: inherit


### PR DESCRIPTION
# Pull Request

## Summary

- Specify language: rust, container-tag: 1.93, and registry-publish: true for crates.io publishing

## Issue Linkage

- Ref wphillipmoore/standard-actions#412

## Testing

- `st-docker-run -- st-validate`

## Notes

- -