### PR TITLE
chore: migrate to mq-rest-admin-project org and vergil tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "extraKnownMarketplaces": {
-    "standard-tooling-marketplace": {
+    "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/standard-tooling-plugin"
+        "repo": "vergil-project/vergil-plugin"
       }
     }
   },
   "enabledPlugins": {
-    "standard-tooling@standard-tooling-marketplace": true
+    "vergil@vergil-marketplace": true
   }
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Canonical source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
+# Canonical source: vergil-project/vergil-tooling/.github/ISSUE_TEMPLATE/config.yml
 # Do not modify repo-local copies — update the canonical source and re-sync.
 #
 blank_issues_enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 > **Do not create PRs manually.**
-> Use [`st-submit-pr`](https://wphillipmoore.github.io/standard-tooling/reference/dev/submit-pr/).
+> Use [`vrg-submit-pr`](https://vergil-project.github.io/vergil-tooling/reference/dev/submit-pr/).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CD
 
 on:
@@ -14,20 +14,22 @@ permissions:
 
 jobs:
   docs:
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
-        https://github.com/wphillipmoore/mq-rest-admin-common.git
+        https://github.com/mq-rest-admin-project/mq-rest-admin-common.git
         .mq-rest-admin-common
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
     with:
       language: rust
       container-tag: "1.93"
       registry-publish: true
-    secrets: inherit
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CI
 
 on:
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
     with:
       language: rust
       versions: ${{ inputs.rust-versions || '["1.92", "1.93"]' }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup MQ environment
         # yamllint disable-line rule:line-length
-        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+        uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           project-name: "mqrest-rust-${{ matrix.project-suffix }}"
           qm1-rest-port: ${{ matrix.qm1-rest-port }}
@@ -87,13 +87,13 @@ jobs:
         run: cargo test --features integration,examples
 
   quality:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: rust
       versions: ${{ inputs.rust-versions || '["1.92", "1.93"]' }}
 
   security:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     with:
       language: rust
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -135,7 +135,7 @@ jobs:
           --fail-under-regions ${{ matrix.coverage-regions }}
 
   version:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: rust
       run-release: ${{ inputs.run-release != 'false' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## User Overrides (Optional)
 
@@ -13,15 +13,15 @@ briefly and continue.
 ## Canonical Standards
 
 This repository follows the canonical standards and conventions in the
-`standards-and-conventions` repository.
+`vergil-tooling` repository.
 
 Resolve the local path (preferred):
 
-- `../standards-and-conventions`
+- `../vergil-tooling`
 
 If the local path is unavailable, use the canonical web source:
 
-- <https://github.com/wphillipmoore/standards-and-conventions>
+- <https://github.com/vergil-project/vergil-tooling>
 
 If the canonical standards cannot be retrieved, treat it as a fatal
 exception and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## Memory management
 
@@ -15,9 +15,9 @@ plugin/skill issue) before writing. See that file for the full
 workflow.
 
 Available skills:
-- `/standard-tooling:memory-init` — set up or update the policy header
+- `/vergil:memory-init` — set up or update the policy header
   in a project's `MEMORY.md`.
-- `/standard-tooling:memory-audit` — structured collaborative review
+- `/vergil:memory-audit` — structured collaborative review
   of memory files.
 
 ## Parallel AI agent development
@@ -28,9 +28,9 @@ while preserving shared project memory (which Claude Code derives from the
 session's starting CWD).
 
 **Canonical spec:**
-[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+[`vergil-tooling/docs/specs/worktree-convention.md`](https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/worktree-convention.md)
 — full rationale, trust model, failure modes, and memory-path implications.
-The canonical text lives in `standard-tooling`; this section is the local
+The canonical text lives in `vergil-tooling`; this section is the local
 on-ramp.
 
 ### Structure
@@ -109,12 +109,12 @@ rustup show
 ### Validation
 
 ```bash
-st-docker-run -- st-validate   # Canonical validation (runs in dev container)
+vrg-docker-run -- vrg-validate   # Canonical validation (runs in dev container)
 ```
 
 ### CI
 
-PR CI uses v1.5 reusable workflows from standard-actions: quality
+PR CI uses v2.0 reusable workflows from vergil-actions: quality
 (lint + typecheck), test, audit, security, and release. Bespoke jobs
 remain for unit tests (per-version coverage thresholds) and integration
 tests (MQ containers).
@@ -128,13 +128,13 @@ cargo test
 ### Local MQ Container
 
 The MQ development environment is owned by the
-[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
+[mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment)
 repository. Clone it as a sibling directory before running lifecycle
 scripts:
 
 ```bash
 # Prerequisite (one-time)
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
 
 # Start the containerized MQ queue managers
 ./scripts/dev/mq_start.sh
@@ -167,7 +167,7 @@ Port assignments are explicit in each `scripts/dev/mq_*.sh` script via
 `QM1_REST_PORT`, `QM2_REST_PORT`, `QM1_MQ_PORT`, and `QM2_MQ_PORT` exports.
 Rust uses offset ports (9483/9484, 1454/1455) to avoid conflicts with other
 language repos. See the
-[port allocation table](https://github.com/wphillipmoore/mq-rest-admin-common)
+[port allocation table](https://github.com/mq-rest-admin-project/mq-rest-admin-common)
 in mq-rest-admin-common for the full cross-language map.
 
 ## Architecture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2024"
 rust-version = "1.92"
 description = "Rust wrapper for the IBM MQ administrative REST API"
 license = "GPL-3.0-or-later"
-repository = "https://github.com/wphillipmoore/mq-rest-admin-rust"
+repository = "https://github.com/mq-rest-admin-project/mq-rest-admin-rust"
 keywords = ["ibm-mq", "rest-api", "mqsc", "message-queue"]
 categories = ["api-bindings"]
 readme = "README.md"
-documentation = "https://wphillipmoore.github.io/mq-rest-admin-rust/"
+documentation = "https://mq-rest-admin-project.github.io/mq-rest-admin-rust/"
 
 [dependencies]
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ for queue in &queues {
 
 ## Documentation
 
-Full documentation: <https://wphillipmoore.github.io/mq-rest-admin-rust/>
+Full documentation: <https://mq-rest-admin-project.github.io/mq-rest-admin-rust/>
 
 ## Development
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -14,21 +14,21 @@
 - Before modifying any files, check the current branch with `git status -sb`.
 - If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
-- Enable repository git hooks before committing: `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`.
+- Enable repository git hooks before committing: `git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks`.
 
 ## Local validation
 
 Canonical local validation command:
 
 ```bash
-st-docker-run -- st-validate
+vrg-docker-run -- vrg-validate
 ```
 
 ## Tooling requirement
 
 Required for daily workflow:
 
-- `st-docker-run` and `st-validate` from standard-tooling
+- `vrg-docker-run` and `vrg-validate` from vergil-tooling
 - Docker (for dev container and local MQ environment)
 
 ## Merge strategy override
@@ -42,13 +42,13 @@ Required for daily workflow:
 
 ## Commit and PR scripts
 
-AI agents **must** use the `st-commit` and `st-submit-pr` scripts for commits
+AI agents **must** use the `vrg-commit` and `vrg-submit-pr` scripts for commits
 and PR submission. Do not construct commit messages or PR bodies manually.
 
 ### Committing
 
 ```bash
-st-commit \
+vrg-commit \
   --type TYPE --message MESSAGE --agent AGENT \
   [--scope SCOPE] [--body BODY]
 ```
@@ -61,12 +61,12 @@ st-commit \
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from
-`standard-tooling.toml` and the git hooks validate the result.
+`vergil.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 
 ```bash
-st-submit-pr \
+vrg-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
   [--notes TEXT] [--dry-run]

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -64,7 +64,7 @@ Or use the containerized scripts:
 - **Claude Code**: reads `CLAUDE.md`, which loads repository standards
   via include directives.
 - **Codex and other agents**: reads `AGENTS.md`, which loads the same
-  standards plus shared skills from the `standards-and-conventions`
+  standards plus shared skills from the `vergil-tooling`
   repository.
 
 ### Quality expectations

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -32,10 +32,9 @@ mq-rest-admin depends on several sibling repositories:
 
 | Repository | Purpose |
 | --- | --- |
-| [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust) | This project |
-| [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
-| [standard-tooling](https://github.com/wphillipmoore/standard-tooling) | Development tools, Docker images, and git hooks |
-| [mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+| [mq-rest-admin-rust](https://github.com/mq-rest-admin-project/mq-rest-admin-rust) | This project |
+| [vergil-tooling](https://github.com/vergil-project/vergil-tooling) | Canonical project standards, development tools, Docker images, and git hooks |
+| [mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
 
 ## Recommended directory layout
 
@@ -44,17 +43,15 @@ Clone all repositories as siblings:
 ```text
 ~/dev/
 ├── mq-rest-admin-rust/
-├── standards-and-conventions/
-├── standard-tooling/
+├── vergil-tooling/
 └── mq-rest-admin-dev-environment/
 ```
 
 ```bash
 cd ~/dev
-git clone https://github.com/wphillipmoore/mq-rest-admin-rust.git
-git clone https://github.com/wphillipmoore/standards-and-conventions.git
-git clone https://github.com/wphillipmoore/standard-tooling.git
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-rust.git
+git clone https://github.com/vergil-project/vergil-tooling.git
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git
 ```
 
 ## Initial setup
@@ -69,10 +66,10 @@ cargo build
 cargo test
 
 # Enable standard tooling and git hooks
-cd ../standard-tooling && uv sync
-export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH"
+cd ../vergil-tooling && uv sync
+export PATH="../vergil-tooling/.venv/bin:../vergil-tooling/scripts/bin:$PATH"
 cd ../mq-rest-admin-rust
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks
+git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks
 ```
 
 ## Running validation
@@ -120,7 +117,7 @@ validation. The pipeline includes:
 
 - **Unit tests** on the minimum supported Rust version (1.92)
 - **Integration tests** against real MQ queue managers via the shared
-  `wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq` action
+  `mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq` action
 - **Standards compliance** (clippy, fmt, markdown lint, commit
   messages, repository profile)
 - **Dependency audit** (`cargo-deny`)

--- a/docs/site/docs/development/release-workflow.md
+++ b/docs/site/docs/development/release-workflow.md
@@ -22,7 +22,7 @@ any time by changing the version to a minor or major bump instead.
    ```bash
    git checkout -b release/X.Y.Z develop
    git-cliff --tag develop-vX.Y.Z -o CHANGELOG.md
-   st-commit --type chore --scope release --message "update changelog for vX.Y.Z" --agent claude
+   vrg-commit --type chore --scope release --message "update changelog for vX.Y.Z" --agent claude
    ```
 
 3. **Merge to main** — Open a PR from `release/X.Y.Z` to `main` and

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: mq-rest-admin (Rust)
-site_url: https://wphillipmoore.github.io/mq-rest-admin-rust/
+site_url: https://mq-rest-admin-project.github.io/mq-rest-admin-rust/
 site_description: Rust wrapper for the IBM MQ administrative REST API
-repo_url: https://github.com/wphillipmoore/mq-rest-admin-rust
+repo_url: https://github.com/mq-rest-admin-project/mq-rest-admin-rust
 repo_name: mq-rest-admin-rust
 edit_uri: ""
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,7 +1,7 @@
 # mqrest-rust Standards and Conventions
 
 This repository follows the canonical standards at:
-<https://github.com/wphillipmoore/standards-and-conventions>
+<https://github.com/vergil-project/vergil-tooling>
 
 ## Table of Contents
 
@@ -9,7 +9,7 @@ This repository follows the canonical standards at:
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-<!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
+<!-- include: ../vergil-tooling/docs/standards-and-conventions.md -->
 
 ## Project-specific overlay
 

--- a/scripts/dev/docs-setup.sh
+++ b/scripts/dev/docs-setup.sh
@@ -25,7 +25,7 @@ fi
 
 if [ ! -d "$COMMON_REPO" ]; then
     echo "Error: Common repo not found at $COMMON_REPO"
-    echo "Clone it with: git clone https://github.com/wphillipmoore/mq-rest-admin-common.git $COMMON_REPO"
+    echo "Clone it with: git clone https://github.com/mq-rest-admin-project/mq-rest-admin-common.git $COMMON_REPO"
     exit 1
 fi
 

--- a/vergil.toml
+++ b/vergil.toml
@@ -6,8 +6,7 @@ release-model = "artifact-publishing"
 primary-language = "rust"
 
 [project.co-authors]
-claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
-codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
 
 [ci]
 versions = ["1.92", "1.93"]
@@ -21,4 +20,4 @@ release = true
 docs = true
 
 [dependencies]
-standard-tooling = "v1.4"
+vergil = "v2.0"


### PR DESCRIPTION
## Summary

- Rename `standard-tooling.toml` to `vergil.toml` and adopt vergil v2.0 dependency
- Update CI/CD workflows from `wphillipmoore/standard-actions@v1.5` to `vergil-project/vergil-actions@v2.0`
- Replace `secrets: inherit` with explicit `APP_CLIENT_ID`/`APP_PRIVATE_KEY` secrets block in cd.yml
- Update all repository and documentation URLs from `wphillipmoore` personal account to `mq-rest-admin-project` org
- Consolidate co-author entries (`claude` + `codex`) to single `wphillipmoore-agent` identity
- Migrate Claude Code plugin config from `standard-tooling-marketplace` to `vergil-marketplace`
- Update all CLI tool references (`st-*` to `vrg-*`) and standards references across docs

Ref mq-rest-admin-project/mq-rest-admin-common#195

## Test plan

- [ ] CI workflows resolve `vergil-project/vergil-actions@v2.0` correctly
- [ ] Integration test job resolves `mq-rest-admin-project/mq-rest-admin-dev-environment` action
- [ ] CD docs job clones `mq-rest-admin-project/mq-rest-admin-common` successfully
- [ ] CD release job receives explicit secrets (`APP_CLIENT_ID`, `APP_PRIVATE_KEY`)
- [ ] All documentation links resolve to correct `mq-rest-admin-project` org URLs
- [ ] `vergil.toml` is recognized by vergil tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)