### PR TITLE
chore(tooling): migrate to vergil v2.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.1
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
@@ -25,7 +25,7 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     with:
       language: rust
       container-tag: "1.93"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.1
     with:
       language: rust
       versions: ${{ inputs.rust-versions || '["1.92", "1.93"]' }}
@@ -88,13 +88,13 @@ jobs:
         run: cargo test --features integration,examples
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:
       language: rust
       versions: ${{ inputs.rust-versions || '["1.92", "1.93"]' }}
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
     with:
       language: rust
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -136,7 +136,7 @@ jobs:
           --fail-under-regions ${{ matrix.coverage-regions }}
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
     with:
       language: rust
       run-release: ${{ inputs.run-release != 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -102,6 +103,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
 
   test:
     name: "test / unit / ${{ matrix.rust-version }}"

--- a/vergil.toml
+++ b/vergil.toml
@@ -17,4 +17,4 @@ release = true
 docs = true
 
 [dependencies]
-vergil = "v2.0"
+vergil = "v2.1"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate mq-rest-admin-rust to vergil v2.1: bump pin, six vergil-actions workflow refs, marketplace ref, and grant actions: read to the ci-security caller.

## Issue Linkage

- Ref #114

## Notes

- Scope: vergil.toml v2.0->v2.1; .claude/settings.json marketplace source.ref added as v2.1 (no ref key existed before); 6 vergil-actions refs bumped (4 in ci.yml, 2 in cd.yml). actions:read added to ci.yml top-level permissions and the security job permissions because v2.1 ci-security.yml requires it from callers (vergil-actions#693/#698); without it the caller startup-fails. Version divergence: VERSION=1.2.3, latest tag develop-v1.2.2 (one patch ahead, normal pending-release; VERSION left untouched). Validate GREEN; repo-config audit local: compliant (remote gh api 403 expected).